### PR TITLE
Explicitly import Meshes.Geometry

### DIFF
--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -1,11 +1,11 @@
 module MeshIntegrals
 using CliffordNumbers: CliffordNumbers, VGA, ∧
 using CoordRefSystems: CoordRefSystems, CRS
+using Meshes: Meshes, Geometry
 
 import FastGaussQuadrature
 import HCubature
 import LinearAlgebra
-import Meshes
 import QuadGK
 import Unitful
 

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -14,10 +14,10 @@ finite-difference approximation with step size `ε`.
 - `ε`: step size to use for the finite-difference approximation
 """
 function jacobian(
-        geometry::G,
+        geometry::Geometry,
         ts::V;
         ε = 1e-6
-) where {G <: Meshes.Geometry, V <: Union{AbstractVector, Tuple}}
+) where {V <: Union{AbstractVector, Tuple}}
     Dim = Meshes.paramdim(geometry)
     if Dim != length(ts)
         throw(ArgumentError("ts must have same number of dimensions as geometry."))
@@ -89,9 +89,9 @@ Calculate the differential element (length, area, volume, etc) of the parametric
 function for `geometry` at arguments `ts`.
 """
 function differential(
-        geometry::G,
+        geometry::Geometry,
         ts::V
-) where {M, CRS, G <: Meshes.Geometry{M, CRS}, V <: Union{AbstractVector, Tuple}}
+) where {V <: Union{AbstractVector, Tuple}}
     # Calculate the Jacobian, convert Vec -> KVector
     J = jacobian(geometry, ts)
     J_kvecs = Iterators.map(_kvector, J)

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -23,11 +23,11 @@ function integral end
 
 # If only f and geometry are specified, select default rule
 function integral(
-        f::F,
-        geometry::G,
+        f::Function,
+        geometry::Geometry,
         rule::I = Meshes.paramdim(geometry) == 1 ? GaussKronrod() : HAdaptiveCubature();
         kwargs...
-) where {F <: Function, G <: Meshes.Geometry, I <: IntegrationRule}
+) where {I <: IntegrationRule}
     _integral(f, geometry, rule; kwargs...)
 end
 

--- a/src/integral_aliases.jl
+++ b/src/integral_aliases.jl
@@ -15,11 +15,11 @@ Rule types available:
 - HAdaptiveCubature
 """
 function lineintegral(
-        f::F,
-        geometry::G,
-        rule::I = GaussKronrod();
+        f::Function,
+        geometry::Geometry,
+        rule::IntegrationRule = GaussKronrod();
         kwargs...
-) where {F <: Function, G <: Meshes.Geometry, I <: IntegrationRule}
+)
     N = Meshes.paramdim(geometry)
 
     if N == 1
@@ -47,11 +47,11 @@ Algorithm types available:
 - HAdaptiveCubature (default)
 """
 function surfaceintegral(
-        f::F,
-        geometry::G,
-        rule::I = HAdaptiveCubature();
+        f::Function,
+        geometry::Geometry,
+        rule::IntegrationRule = HAdaptiveCubature();
         kwargs...
-) where {F <: Function, G <: Meshes.Geometry, I <: IntegrationRule}
+)
     N = Meshes.paramdim(geometry)
 
     if N == 2
@@ -79,11 +79,11 @@ Algorithm types available:
 - HAdaptiveCubature (default)
 """
 function volumeintegral(
-        f::F,
-        geometry::G,
-        rule::I = HAdaptiveCubature();
+        f::Function,
+        geometry::Geometry,
+        rule::IntegrationRule = HAdaptiveCubature();
         kwargs...
-) where {F <: Function, G <: Meshes.Geometry, I <: IntegrationRule}
+)
     N = Meshes.paramdim(geometry)
 
     if N == 3

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,11 +8,6 @@ function _gausslegendre(T, n)
     return T.(xs), T.(ws)
 end
 
-# Extract the length units used by the CRS of a Geometry
-function _units(g::Meshes.Geometry{M, CRS}) where {M, CRS}
-    return Unitful.unit(CoordRefSystems.lentype(CRS))
-end
-
 # Common error message structure
 function _error_unsupported_combination(geometry, rule)
     msg = "Integrating a $geometry using a $rule rule not supported."
@@ -20,7 +15,7 @@ function _error_unsupported_combination(geometry, rule)
 end
 
 ################################################################################
-#                        CliffordNumbers Interface
+#                        CliffordNumbers and Units
 ################################################################################
 
 # Meshes.Vec -> ::CliffordNumber.KVector
@@ -28,3 +23,6 @@ function _kvector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     ucoords = Iterators.map(Unitful.ustrip, v.coords)
     return CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...)
 end
+
+# Extract the length units used by the CRS of a Geometry
+_units(::Geometry{M, CRS}) where {M, CRS} = Unitful.unit(CoordRefSystems.lentype(CRS))


### PR DESCRIPTION
## Changes
- Explicitly import `Meshes.Geometry`. This is a frequently-used reference with a fairly obvious namespace source, and being able to reference it implicitly will reduce function signature line lengths.
- Update method signatures, eliminating unnecessary `where` clauses. I'm told that there's no functional/performance difference between a function argument being `f(x::SuperType)` vs `f(x::ST) where {ST <: SuperType}`.