### PR TITLE
Implement benchmarking with AirspeedVelocity.jl

### DIFF
--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -22,7 +22,7 @@ jobs:
               id: extract-package-name
               run: |
                 PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
-                echo "::set-output name=package_name::$PACKAGE_NAME"
+                echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
             - name: Build AirspeedVelocity
               env:
                 JULIA_NUM_THREADS: 2

--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -1,7 +1,7 @@
 name: Benchmark a Pull Request
 
 on:
-  pull_request_target:
+  push:
     branches:
       - main
 

--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -1,0 +1,78 @@
+name: Benchmark a Pull Request
+
+on:
+  pull_request_target:
+    branches:
+      - master
+
+permissions:
+  pull-requests: write
+
+jobs:
+    generate_plots:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - uses: julia-actions/setup-julia@v1
+              with:
+                version: "1.8"
+            - uses: julia-actions/cache@v1
+            - name: Extract Package Name from Project.toml
+              id: extract-package-name
+              run: |
+                PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
+                echo "::set-output name=package_name::$PACKAGE_NAME"
+            - name: Build AirspeedVelocity
+              env:
+                JULIA_NUM_THREADS: 2
+              run: |
+                # Lightweight build step, as sometimes the runner runs out of memory:
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+            - name: Add ~/.julia/bin to PATH
+              run: |
+                echo "$HOME/.julia/bin" >> $GITHUB_PATH
+            - name: Run benchmarks
+              run: |
+                echo $PATH
+                ls -l ~/.julia/bin
+                mkdir results
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/ --tune
+            - name: Create plots from benchmarks
+              run: |
+                mkdir -p plots
+                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
+            - name: Upload plot as artifact
+              uses: actions/upload-artifact@v2
+              with:
+                name: plots
+                path: plots
+            - name: Create markdown table from benchmarks
+              run: |
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                echo '### Benchmark Results' > body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                cat table.md >> body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                echo '### Benchmark Plots' >> body.md
+                echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
+                echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
+
+            - name: Find Comment
+              uses: peter-evans/find-comment@v2
+              id: fcbenchmark
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                comment-author: 'github-actions[bot]'
+                body-includes: Benchmark Results
+
+            - name: Comment on PR
+              uses: peter-evans/create-or-update-comment@v3
+              with:
+                comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
+                issue-number: ${{ github.event.pull_request.number }}
+                body-path: body.md
+                edit-mode: replace

--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -3,7 +3,7 @@ name: Benchmark a Pull Request
 on:
   pull_request_target:
     branches:
-      - master
+      - main
 
 permissions:
   pull-requests: write

--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -38,7 +38,7 @@ jobs:
                 echo $PATH
                 ls -l ~/.julia/bin
                 mkdir results
-                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/ --tune
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --tune
             - name: Create plots from benchmarks
               run: |
                 mkdir -p plots

--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: julia-actions/setup-julia@v2
               with:
-                version: "1.8"
+                version: "1.10"
             - uses: julia-actions/cache@v2
             - name: Extract Package Name from Project.toml
               id: extract-package-name

--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 jobs:
-    generate_plots:
+    benchmark:
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -13,11 +13,11 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: julia-actions/setup-julia@v1
+            - uses: actions/checkout@v4
+            - uses: julia-actions/setup-julia@v2
               with:
                 version: "1.8"
-            - uses: julia-actions/cache@v1
+            - uses: julia-actions/cache@v2
             - name: Extract Package Name from Project.toml
               id: extract-package-name
               run: |
@@ -44,7 +44,7 @@ jobs:
                 mkdir -p plots
                 benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
             - name: Upload plot as artifact
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                 name: plots
                 path: plots
@@ -62,7 +62,7 @@ jobs:
                 echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
 
             - name: Find Comment
-              uses: peter-evans/find-comment@v2
+              uses: peter-evans/find-comment@v3
               id: fcbenchmark
               with:
                 issue-number: ${{ github.event.pull_request.number }}
@@ -70,7 +70,7 @@ jobs:
                 body-includes: Benchmark Results
 
             - name: Comment on PR
-              uses: peter-evans/create-or-update-comment@v3
+              uses: peter-evans/create-or-update-comment@v4
               with:
                 comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
                 issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/AirspeedVelocity.yml
+++ b/.github/workflows/AirspeedVelocity.yml
@@ -1,7 +1,7 @@
 name: Benchmark a Pull Request
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -2,10 +2,8 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 BenchmarkTools = "1.5"
 LinearAlgebra = "1"
 Meshes = "0.50, 0.51, 0.52"
-Unitful = "1.19"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,9 +1,11 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 BenchmarkTools = "1.5"
+LinearAlgebra = "1"
 Meshes = "0.50, 0.51, 0.52"
 Unitful = "1.19"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[compat]
+BenchmarkTools = "1.5"
+Meshes = "0.50, 0.51, 0.52"
+Unitful = "1.19"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -26,8 +26,7 @@ geometries = (
 
 SUITE["Integrals"] = let s = BenchmarkGroup()
     for (int, rule, geometry) in Iterators.product(integrands, rules, geometries)
-        n1, n2 = geometry.name,"$(int.name) $(rule.name)"
-        N = rule.N
+        n1, n2, N = geometry.name,"$(int.name) $(rule.name)", rule.N
         s[n1, n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=N
     end
     s

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,28 +1,23 @@
 using BenchmarkTools
+using LinearAlgebra: norm
 using Meshes
 using MeshIntegrals
 using Unitful
 
 const SUITE = BenchmarkGroup()
-
 SUITE["Integrals"] = BenchmarkGroup()
 
-SUITE["Integrals"]["Meshes.Segment"] = let s = BenchmarkGroup()
-    # Setup
-    φ, θ = (7pi / 6, pi / 3)  # Arbitrary spherical angles
-    pt_a = Point(0.0u"m", 0.0u"m", 0.0u"m")
-    pt_b = Point(sin(θ) * cos(φ) * u"m", sin(θ) * sin(φ) * u"m", cos(θ) * u"m")
-    segment = Segment(pt_a, pt_b)
-    f(p) = norm(to(p))
-    fv(p) = fill(f(p), 3)
+segment = Segment(Point(0, 0, 0), Point(1, 1, 1))
+f(p) = norm(to(p))
+fv(p) = fill(f(p), 3)
 
-    s["Scalar-valued GaussLegendre"] = @benchmarkable integral($f, $segment, GaussLegendre(100)) evals=1000
-    s["Scalar-valued GaussKronrod"] = @benchmarkable integral($f, $segment, GaussKronrod()) evals=1000
-    s["Scalar-valued HAdaptiveCubature"] = @benchmarkable integral($f, $segment, HAdaptiveCubature()) evals=1000
+SUITE["Integrals"]["Meshes.Segment"] = BenchmarkGroup()
+let s = SUITE["Integrals"]["Meshes.Segment"]
+    s["Scalar GaussLegendre"] = @benchmarkable integral($f, $segment, GaussLegendre(100)) evals=1000
+    s["Scalar GaussKronrod"] = @benchmarkable integral($f, $segment, GaussKronrod()) evals=1000
+    s["Scalar HAdaptiveCubature"] = @benchmarkable integral($f, $segment, HAdaptiveCubature()) evals=1000
 
-    s["Vector-valued GaussLegendre"] = @benchmarkable integral($fv, $segment, GaussLegendre(100)) evals=1000
-    s["Vector-valued GaussKronrod"] = @benchmarkable integral($fv, $segment, GaussKronrod()) evals=1000
-    s["Vector-valued HAdaptiveCubature"] = @benchmarkable integral($fv, $segment, HAdaptiveCubature()) evals=1000
-
-    s
+    s["Vector GaussLegendre"] = @benchmarkable integral($fv, $segment, GaussLegendre(100)) evals=1000
+    s["Vector GaussKronrod"] = @benchmarkable integral($fv, $segment, GaussKronrod()) evals=1000
+    s["Vector HAdaptiveCubature"] = @benchmarkable integral($fv, $segment, HAdaptiveCubature()) evals=1000
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -8,16 +8,15 @@ const SUITE = BenchmarkGroup()
 SUITE["Integrals"] = BenchmarkGroup()
 
 segment = Segment(Point(0, 0, 0), Point(1, 1, 1))
-f(p) = norm(to(p))
+f(p) = LinearAlgebra.norm(to(p))
 fv(p) = fill(f(p), 3)
 
-SUITE["Integrals"]["Meshes.Segment"] = BenchmarkGroup()
-let s = SUITE["Integrals"]["Meshes.Segment"]
+SUITE["Integrals"]["Meshes.Segment"] = let s = BenchmarkGroup()
     s["Scalar GaussLegendre"] = @benchmarkable integral($f, $segment, GaussLegendre(100)) evals=1000
     s["Scalar GaussKronrod"] = @benchmarkable integral($f, $segment, GaussKronrod()) evals=1000
     s["Scalar HAdaptiveCubature"] = @benchmarkable integral($f, $segment, HAdaptiveCubature()) evals=1000
-
     s["Vector GaussLegendre"] = @benchmarkable integral($fv, $segment, GaussLegendre(100)) evals=1000
     s["Vector GaussKronrod"] = @benchmarkable integral($fv, $segment, GaussKronrod()) evals=1000
     s["Vector HAdaptiveCubature"] = @benchmarkable integral($fv, $segment, HAdaptiveCubature()) evals=1000
+    s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,6 +6,10 @@ using Unitful
 
 const SUITE = BenchmarkGroup()
 
+############################################################################################
+#                                      Integrals
+############################################################################################
+
 integrands = (
     (name = "Scalar", f = p -> norm(to(p))),
     (name = "Vector", f = p -> fill(norm(to(p)), 3))
@@ -26,6 +30,19 @@ SUITE["Integrals"] = let s = BenchmarkGroup()
         N = rule.N
         s[n1, n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=N
     end
+    s
+end
+
+############################################################################################
+#                                      Differentials
+############################################################################################
+
+sphere = geometries[2].item
+differential = MeshIntegrals.differential
+
+SUITE["Differentials"] = let s = BenchmarkGroup()
+    s["Jacobian"] = @benchmarkable jacobian($sphere, $(0.5, 0.5)) evals=1000
+    s["Differential"] = @benchmarkable differential($sphere, $(0.5, 0.5)) evals=1000
     s
 end
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -14,19 +14,16 @@ SUITE["Integrals"]["Meshes.Segment"] = let s = BenchmarkGroup()
     pt_b = Point(sin(θ) * cos(φ) * u"m", sin(θ) * sin(φ) * u"m", cos(θ) * u"m")
     segment = Segment(pt_a, pt_b)
 
-    function f(p::P) where {P <: Meshes.Point}
-        a, b = (7.1, 4.6)  # arbitrary constants > 0
-        r = ustrip(u"m", norm(to(p)))
-        exp(r * log(a) + (1 - r) * log(b))
-    end
+    f(p) = norm(to(p))
     fv(p) = fill(f(p), 3)
 
-    s["Scalar-valued GaussLegendre"] = @benchmarkable integral(f, segment, GaussLegendre(100)) evals=1000
-    s["Scalar-valued GaussKronrod"] = @benchmarkable integral(f, segment, GaussKronrod()) evals=1000
-    s["Scalar-valued HAdaptiveCubature"] = @benchmarkable integral(f, segment, HAdaptiveCubature()) evals=1000
+    s["Scalar-valued GaussLegendre"] = @benchmarkable integral($f, $segment, GaussLegendre(100)) evals=1000
+    s["Scalar-valued GaussKronrod"] = @benchmarkable integral($f, $segment, GaussKronrod()) evals=1000
+    s["Scalar-valued HAdaptiveCubature"] = @benchmarkable integral($f, $segment, HAdaptiveCubature()) evals=1000
 
-    s["Vector-valued GaussLegendre"] = @benchmarkable integral(fv, segment, GaussLegendre(100)) evals=1000
-    s["Vector-valued GaussKronrod"] = @benchmarkable integral(fv, segment, GaussKronrod()) evals=1000
-    s["Vector-valued HAdaptiveCubature"] = @benchmarkable integral(fv, segment, HAdaptiveCubature()) evals=1000
+    s["Vector-valued GaussLegendre"] = @benchmarkable integral($fv, $segment, GaussLegendre(100)) evals=1000
+    s["Vector-valued GaussKronrod"] = @benchmarkable integral($fv, $segment, GaussKronrod()) evals=1000
+    s["Vector-valued HAdaptiveCubature"] = @benchmarkable integral($fv, $segment, HAdaptiveCubature()) evals=1000
+
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -8,12 +8,11 @@ const SUITE = BenchmarkGroup()
 SUITE["Integrals"] = BenchmarkGroup()
 
 SUITE["Integrals"]["Meshes.Segment"] = let s = BenchmarkGroup()
-    # Connect a line segment from the origin to an arbitrary point on the unit sphere
+    # Setup
     φ, θ = (7pi / 6, pi / 3)  # Arbitrary spherical angles
     pt_a = Point(0.0u"m", 0.0u"m", 0.0u"m")
     pt_b = Point(sin(θ) * cos(φ) * u"m", sin(θ) * sin(φ) * u"m", cos(θ) * u"m")
     segment = Segment(pt_a, pt_b)
-
     f(p) = norm(to(p))
     fv(p) = fill(f(p), 3)
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -26,7 +26,7 @@ geometries = (
 SUITE["Integrals"] = let s = BenchmarkGroup()
     for (int, rule, geometry) in Iterators.product(integrands, rules, geometries)
         n1, n2, N = geometry.name, "$(int.name) $(rule.name)", rule.N
-        s[n1, n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=N
+        s[n1][n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=N
     end
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -11,14 +11,14 @@ segment = Segment(Point(0, 0, 0), Point(1, 1, 1))
 f(p) = LinearAlgebra.norm(to(p))
 fv(p) = fill(f(p), 3)
 
-rules = (
-    (name="GaussLegendre", rule=GaussLegendre(100)),
-    (name="GaussKronrod", rule=GaussKronrod()),
-    (name="HAdaptiveCubature", rule=HAdaptiveCubature())
-)
 integrands = (
-    (name="Scalar", f=f),
-    (name="Vector", f=fv)
+    (name = "Scalar", f = f),
+    (name = "Vector", f = fv)
+)
+rules = (
+    (name = "GaussLegendre", rule = GaussLegendre(100)),
+    (name = "GaussKronrod", rule = GaussKronrod()),
+    (name = "HAdaptiveCubature", rule = HAdaptiveCubature())
 )
 
 SUITE["Integrals"]["Meshes.Segment"] = let s = BenchmarkGroup()

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,7 +2,6 @@ using BenchmarkTools
 using LinearAlgebra
 using Meshes
 using MeshIntegrals
-using Unitful
 
 const SUITE = BenchmarkGroup()
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -11,9 +11,9 @@ integrands = (
     (name = "Vector", f = p -> fill(norm(to(p)), 3))
 )
 rules = (
-    (name = "GaussLegendre", rule = GaussLegendre(100)),
-    (name = "GaussKronrod", rule = GaussKronrod()),
-    (name = "HAdaptiveCubature", rule = HAdaptiveCubature())
+    (name = "GaussLegendre", rule = GaussLegendre(100), N = 100),
+    (name = "GaussKronrod", rule = GaussKronrod(), N = 100),
+    (name = "HAdaptiveCubature", rule = HAdaptiveCubature(), N = 500)
 )
 geometries = (
     (name = "Meshes.Segment", item = Segment(Point(0, 0, 0), Point(1, 1, 1))),
@@ -22,9 +22,9 @@ geometries = (
 
 SUITE["Integrals"] = let s = BenchmarkGroup()
     for (int, rule, geometry) in Iterators.product(integrands, rules, geometries)
-        n1 = geometry.name
-        n2 = "$(int.name) $(rule.name)"
-        s[n1, n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=1000
+        n1, n2 = geometry.name,"$(int.name) $(rule.name)"
+        N = rule.N
+        s[n1, n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=N
     end
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -8,7 +8,7 @@ const SUITE = BenchmarkGroup()
 SUITE["Integrals"] = BenchmarkGroup()
 
 segment = Segment(Point(0, 0, 0), Point(1, 1, 1))
-f(p) = LinearAlgebra.norm(to(p))
+f(p) = norm(to(p))
 fv(p) = fill(f(p), 3)
 
 integrands = (
@@ -28,3 +28,6 @@ SUITE["Integrals"]["Meshes.Segment"] = let s = BenchmarkGroup()
     end
     s
 end
+
+#tune!(SUITE)
+#run(SUITE, verbose=true)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -26,7 +26,7 @@ geometries = (
 
 SUITE["Integrals"] = let s = BenchmarkGroup()
     for (int, rule, geometry) in Iterators.product(integrands, rules, geometries)
-        n1, n2, N = geometry.name,"$(int.name) $(rule.name)", rule.N
+        n1, n2, N = geometry.name, "$(int.name) $(rule.name)", rule.N
         s[n1, n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=N
     end
     s

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -21,7 +21,7 @@ geometries = (
 )
 
 SUITE["Integrals"] = let s = BenchmarkGroup()
-    for (int, rule, g) in Iterators.product(integrands, rules, geometries)
+    for (int, rule, geometry) in Iterators.product(integrands, rules, geometries)
         n1 = geometry.name
         n2 = "$(int.name) $(rule.name)"
         s[n1, n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=1000

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -5,26 +5,26 @@ using MeshIntegrals
 using Unitful
 
 const SUITE = BenchmarkGroup()
-SUITE["Integrals"] = BenchmarkGroup()
-
-segment = Segment(Point(0, 0, 0), Point(1, 1, 1))
-f(p) = norm(to(p))
-fv(p) = fill(f(p), 3)
 
 integrands = (
-    (name = "Scalar", f = f),
-    (name = "Vector", f = fv)
+    (name = "Scalar", f = p -> norm(to(p))),
+    (name = "Vector", f = p -> fill(norm(to(p)), 3))
 )
 rules = (
     (name = "GaussLegendre", rule = GaussLegendre(100)),
     (name = "GaussKronrod", rule = GaussKronrod()),
     (name = "HAdaptiveCubature", rule = HAdaptiveCubature())
 )
+geometries = (
+    (name = "Meshes.Segment", item = Segment(Point(0, 0, 0), Point(1, 1, 1))),
+    (name = "Meshes.Sphere", item = Sphere(Point(0, 0, 0), 1.0))
+)
 
-SUITE["Integrals"]["Meshes.Segment"] = let s = BenchmarkGroup()
-    for (int, rule) in Iterators.product(integrands, rules)
-        name = "$(int.name) $(rule.name)"
-        s[name] = @benchmarkable integral($int.f, $segment, $rule.rule) evals=1000
+SUITE["Integrals"] = let s = BenchmarkGroup()
+    for (int, rule, g) in Iterators.product(integrands, rules, geometries)
+        n1 = geometry.name
+        n2 = "$(int.name) $(rule.name)"
+        s[n1, n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule) evals=1000
     end
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,32 @@
+using BenchmarkTools
+using Meshes
+using MeshIntegrals
+using Unitful
+
+const SUITE = BenchmarkGroup()
+
+SUITE["Integrals"] = BenchmarkGroup()
+
+SUITE["Integrals"]["Meshes.Segment"] = let s = BenchmarkGroup()
+    # Connect a line segment from the origin to an arbitrary point on the unit sphere
+    φ, θ = (7pi / 6, pi / 3)  # Arbitrary spherical angles
+    pt_a = Point(0.0u"m", 0.0u"m", 0.0u"m")
+    pt_b = Point(sin(θ) * cos(φ) * u"m", sin(θ) * sin(φ) * u"m", cos(θ) * u"m")
+    segment = Segment(pt_a, pt_b)
+
+    function f(p::P) where {P <: Meshes.Point}
+        a, b = (7.1, 4.6)  # arbitrary constants > 0
+        r = ustrip(u"m", norm(to(p)))
+        exp(r * log(a) + (1 - r) * log(b))
+    end
+    fv(p) = fill(f(p), 3)
+
+    s["Scalar-valued GaussLegendre"] = @benchmarkable integral(f, segment, GaussLegendre(100)) evals=1000
+    s["Scalar-valued GaussKronrod"] = @benchmarkable integral(f, segment, GaussKronrod()) evals=1000
+    s["Scalar-valued HAdaptiveCubature"] = @benchmarkable integral(f, segment, HAdaptiveCubature()) evals=1000
+
+    s["Vector-valued GaussLegendre"] = @benchmarkable integral(fv, segment, GaussLegendre(100)) evals=1000
+    s["Vector-valued GaussKronrod"] = @benchmarkable integral(fv, segment, GaussKronrod()) evals=1000
+    s["Vector-valued HAdaptiveCubature"] = @benchmarkable integral(fv, segment, HAdaptiveCubature()) evals=1000
+    s
+end


### PR DESCRIPTION
## Changes
- Adds a CI Action (duplicate of [this one](https://github.com/MilesCranmer/AirspeedVelocity.jl/blob/master/.github/workflows/benchmark_pr.yml)) that uses AirspeedVelocity.jl to run benchmarks for every new PR
- Adds a benchmark script with a suite containing 14 `@benchmark` entries, testing integrals of `Segment` and `Sphere` (surface), `jacobian`, and `differential`.

Closes #21 