### PR TITLE
WIP: Use a new DifferentiationMethod to dispatch for derivative types

### DIFF
--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -80,17 +80,18 @@ end
 ################################################################################
 
 """
-    differential(geometry, ts)
+    differential(geometry, ts, method=FiniteDifference())
 
 Calculate the differential element (length, area, volume, etc) of the parametric
 function for `geometry` at arguments `ts`.
 """
 function differential(
         geometry::Geometry,
-        ts::V
+        ts::V,
+        method::DifferentiationMethod = FiniteDifference()
 ) where {V <: Union{AbstractVector, Tuple}}
     # Calculate the Jacobian, convert Vec -> KVector
-    J = jacobian(geometry, ts)
+    J = jacobian(geometry, ts, method)
     J_kvecs = Iterators.map(_kvector, J)
 
     # Extract units from Geometry type

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -1,5 +1,21 @@
 ################################################################################
-#                     Jacobian and Differential Elements
+#                               JacobianMethods
+################################################################################
+
+abstract type JacobianMethod end
+
+struct FiniteDifference{T<:AbstractFloat} <: JacobianMethod
+    ε::T
+end
+
+# struct EnzymeAD <: JacobianMethod
+# end
+
+# struct ZygoteAD <: JacobianMethod
+# end
+
+################################################################################
+#                                  Jacobian
 ################################################################################
 
 """

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -2,16 +2,22 @@
 #                               JacobianMethods
 ################################################################################
 
-abstract type JacobianMethod end
+abstract type DifferentiationMethod end
 
-struct FiniteDifference{T<:AbstractFloat} <: JacobianMethod
+"""
+    FiniteDifference(ε)
+
+Use a finite-difference approximation method to calculate derivatives with a
+step size of `ε`.
+"""
+struct FiniteDifference{T<:AbstractFloat} <: DifferentiationMethod
     ε::T
 end
 
-# struct EnzymeAD <: JacobianMethod
+# struct EnzymeAD <: DifferentiationMethod
 # end
 
-# struct ZygoteAD <: JacobianMethod
+# struct ZygoteAD <: DifferentiationMethod
 # end
 
 ################################################################################

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -14,6 +14,9 @@ struct FiniteDifference{T<:AbstractFloat} <: DifferentiationMethod
     ε::T
 end
 
+# If ε not specified, default to 1e-6
+FiniteDifference() = new(1e-6)
+
 # struct EnzymeAD <: DifferentiationMethod
 # end
 

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -40,8 +40,7 @@ function jacobian end
 function jacobian(
         geometry::Geometry,
         ts::V,
-        fd::FiniteDifference;
-        ε = 1e-6
+        fd::FiniteDifference
 ) where {V <: Union{AbstractVector, Tuple}}
     Dim = Meshes.paramdim(geometry)
     if Dim != length(ts)

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -72,36 +72,6 @@ function jacobian(
     return ntuple(n -> ∂ₙr(ts, n), Dim)
 end
 
-function jacobian(
-        bz::Meshes.BezierCurve,
-        ts::V
-) where {V <: Union{AbstractVector, Tuple}}
-    t = only(ts)
-    # Parameter t restricted to domain [0,1] by definition
-    if t < 0 || t > 1
-        throw(DomainError(t, "b(t) is not defined for t outside [0, 1]."))
-    end
-
-    # Aliases
-    P = bz.controls
-    N = Meshes.degree(bz)
-
-    # Ensure that this implementation is tractible: limited by ability to calculate
-    #   binomial(N, N/2) without overflow. It's possible to extend this range by
-    #   converting N to a BigInt, but this results in always returning BigFloat's.
-    N <= 1028 || error("This algorithm overflows for curves with ⪆1000 control points.")
-
-    # Generator for Bernstein polynomial functions
-    B(i, n) = t -> binomial(Int128(n), i) * t^i * (1 - t)^(n - i)
-
-    # Derivative = N Σ_{i=0}^{N-1} sigma(i)
-    #   P indices adjusted for Julia 1-based array indexing
-    sigma(i) = B(i, N - 1)(t) .* (P[(i + 1) + 1] - P[(i) + 1])
-    derivative = N .* sum(sigma, 0:(N - 1))
-
-    return (derivative,)
-end
-
 ################################################################################
 #                          Differential Elements
 ################################################################################

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -25,19 +25,22 @@ end
 ################################################################################
 
 """
-    jacobian(geometry, ts; ε=1e-6)
+    jacobian(geometry, ts, method)
 
-Calculate the Jacobian of a geometry at some parametric point `ts` using a simple
-finite-difference approximation with step size `ε`.
+Calculate the Jacobian of a geometry's parametric function at some point `ts`
+using a particular differentiation method.
 
 # Arguments
 - `geometry`: some `Meshes.Geometry` of N parametric dimensions
 - `ts`: a parametric point specified as a vector or tuple of length N
-- `ε`: step size to use for the finite-difference approximation
+- `method`: the desired `DifferentiationMethod`
 """
+function jacobian end
+
 function jacobian(
         geometry::Geometry,
-        ts::V;
+        ts::V,
+        fd::FiniteDifference;
         ε = 1e-6
 ) where {V <: Union{AbstractVector, Tuple}}
     Dim = Meshes.paramdim(geometry)
@@ -46,7 +49,7 @@ function jacobian(
     end
 
     T = eltype(ts)
-    ε = T(ε)
+    ε = T(fd.ε)
 
     # Get the partial derivative along the n'th axis via finite difference
     #   approximation, where ts is the current parametric position


### PR DESCRIPTION
## Proposed Changes
- Adds a `DifferentiationMethod` abstract type to communicate derivative calculation method
  - `FiniteDifference(ε=1e-6)` is the only method yet defined
  - Added commented-out placeholders for `EnzymeAD` and `ZygoteAD`
- Changes function signatures for `differential` and `jacobian` to 3-argument: `(geometry, coords, ::DifferentiationMethod)`

TODO
- Change `integral` calls

Ref #35 