### PR TITLE
Implement _ParametricGeometry

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -2,8 +2,11 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 BenchmarkTools = "1.5"
 LinearAlgebra = "1"
 Meshes = "0.50, 0.51, 0.52"
+Unitful = "1.19"
+julia = "1.9"

--- a/docs/src/supportmatrix.md
+++ b/docs/src/supportmatrix.md
@@ -55,7 +55,7 @@ using an equivalent H-Adaptive Cubature rule, so support for this usage is not r
 | `SimpleMesh` | [🎗️](https://github.com/JuliaGeometry/MeshIntegrals.jl/issues/27) | [🎗️](https://github.com/JuliaGeometry/MeshIntegrals.jl/issues/27) | [🎗️](https://github.com/JuliaGeometry/MeshIntegrals.jl/issues/27) |
 | `Sphere` in `𝔼{2}` | ✅ | ✅ | ✅ |
 | `Sphere` in `𝔼{3}` | ✅ | ⚠️ | ✅ |
-| `Tetrahedron` in `𝔼{3}` | [🎗️](https://github.com/JuliaGeometry/MeshIntegrals.jl/issues/40) | ✅ | [🎗️](https://github.com/JuliaGeometry/MeshIntegrals.jl/issues/40) |
+| `Tetrahedron` | ✅ | ⚠️ | ✅ |
 | `Triangle` | ✅ | ✅ | ✅ |
 | `Torus` | ✅ | ⚠️ | ✅ |
 | `Wedge` | [🎗️](https://github.com/JuliaGeometry/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/JuliaGeometry/MeshIntegrals.jl/issues/28) | [🎗️](https://github.com/JuliaGeometry/MeshIntegrals.jl/issues/28) |

--- a/src/MeshIntegrals.jl
+++ b/src/MeshIntegrals.jl
@@ -24,6 +24,7 @@ include("integral_aliases.jl")
 export lineintegral, surfaceintegral, volumeintegral
 
 # Integration methods specialized for particular geometries
+include("specializations/_ParametricGeometry.jl")
 include("specializations/BezierCurve.jl")
 include("specializations/ConeSurface.jl")
 include("specializations/CylinderSurface.jl")

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -104,7 +104,7 @@ function _integral(
 
     # HCubature doesn't support functions that output Unitful Quantity types
     # Establish the units that are output by f
-    testpoint_parametriccoord = zeros(FP, N)
+    testpoint_parametriccoord = _zeros(FP, N)
     integrandunits = Unitful.unit.(integrand(testpoint_parametriccoord))
     # Create a wrapper that returns only the value component in those units
     uintegrand(ts) = Unitful.ustrip.(integrandunits, integrand(ts))

--- a/src/specializations/BezierCurve.jl
+++ b/src/specializations/BezierCurve.jl
@@ -32,95 +32,25 @@ calculating Jacobians that are used to calculate differential elements
 steep performance cost, especially for curves with a large number of control points.
 """
 function integral(
-        f,
-        curve::Meshes.BezierCurve,
-        rule::GaussLegendre;
-        diff_method::DM = _default_method(curve),
-        FP::Type{T} = Float64,
-        alg::Meshes.BezierEvalMethod = Meshes.Horner()
-) where {DM <: DifferentiationMethod, T <: AbstractFloat}
-    # Compute Gauss-Legendre nodes/weights for x in interval [-1,1]
-    xs, ws = _gausslegendre(FP, rule.n)
+    f,
+    curve::Meshes.BezierCurve,
+    rule::IntegrationRule;
+    alg::Meshes.BezierEvalMethod = Meshes.Horner(),
+    kwargs...
+)
+    # Generate a _ParametricGeometry whose parametric function auto-applies the alg kwarg
+    paramfunction(t) = _parametric(curve, t, alg)
+    param_curve = _ParametricGeometry(paramfunction, 1)
 
-    # Change of variables: x [-1,1] ↦ t [0,1]
-    t(x) = (1 // 2) * x + (1 // 2)
-    point(x) = curve(t(x), alg)
-    integrand(x) = f(point(x)) * differential(curve, (t(x),), diff_method)
-
-    # Integrate f along curve and apply domain-correction for [-1,1] ↦ [0, length]
-    return (1 // 2) * sum(w .* integrand(x) for (w, x) in zip(ws, xs))
+    # Integrate the _ParametricGeometry using the standard methods
+    return _integral(f, param_curve, rule; kwargs...)
 end
 
-function integral(
-        f,
-        curve::Meshes.BezierCurve,
-        rule::GaussKronrod;
-        diff_method::DM = _default_method(curve),
-        FP::Type{T} = Float64,
-        alg::Meshes.BezierEvalMethod = Meshes.Horner()
-) where {DM <: DifferentiationMethod, T <: AbstractFloat}
-    point(t) = curve(t, alg)
-    integrand(t) = f(point(t)) * differential(curve, (t,), diff_method)
-    return QuadGK.quadgk(integrand, zero(FP), one(FP); rule.kwargs...)[1]
-end
-
-function integral(
-        f,
-        curve::Meshes.BezierCurve,
-        rule::HAdaptiveCubature;
-        diff_method::DM = _default_method(curve),
-        FP::Type{T} = Float64,
-        alg::Meshes.BezierEvalMethod = Meshes.Horner()
-) where {DM <: DifferentiationMethod, T <: AbstractFloat}
-    point(t) = curve(t, alg)
-    integrand(ts) = f(point(only(ts))) * differential(curve, ts, diff_method)
-
-    # HCubature doesn't support functions that output Unitful Quantity types
-    # Establish the units that are output by f
-    testpoint_parametriccoord = zeros(FP, 1)
-    integrandunits = Unitful.unit.(integrand(testpoint_parametriccoord))
-    # Create a wrapper that returns only the value component in those units
-    uintegrand(ts) = Unitful.ustrip.(integrandunits, integrand(ts))
-    # Integrate only the unitless values
-    value = HCubature.hcubature(uintegrand, _zeros(FP, 1), _ones(FP, 1); rule.kwargs...)[1]
-
-    # Reapply units
-    return value .* integrandunits
-end
 
 ################################################################################
-#                               jacobian
+#                              Parametric
 ################################################################################
 
-function jacobian(
-        bz::Meshes.BezierCurve,
-        ts::V,
-        diff_method::Analytical
-) where {V <: Union{AbstractVector, Tuple}}
-    t = only(ts)
-    # Parameter t restricted to domain [0,1] by definition
-    if t < 0 || t > 1
-        throw(DomainError(t, "b(t) is not defined for t outside [0, 1]."))
-    end
-
-    # Aliases
-    P = bz.controls
-    N = Meshes.degree(bz)
-
-    # Ensure that this implementation is tractible: limited by ability to calculate
-    #   binomial(N, N/2) without overflow. It's possible to extend this range by
-    #   converting N to a BigInt, but this results in always returning BigFloat's.
-    N <= 1028 || error("This algorithm overflows for curves with ⪆1000 control points.")
-
-    # Generator for Bernstein polynomial functions
-    B(i, n) = t -> binomial(Int128(n), i) * t^i * (1 - t)^(n - i)
-
-    # Derivative = N Σ_{i=0}^{N-1} sigma(i)
-    #   P indices adjusted for Julia 1-based array indexing
-    sigma(i) = B(i, N - 1)(t) .* (P[(i + 1) + 1] - P[(i) + 1])
-    derivative = N .* sum(sigma, 0:(N - 1))
-
-    return (derivative,)
+function _parametric(curve::Meshes.BezierCurve, t, alg::Meshes.BezierEvalMethod)
+    return curve(t, alg)
 end
-
-_has_analytical(::Type{T}) where {T <: Meshes.BezierCurve} = true

--- a/src/specializations/BezierCurve.jl
+++ b/src/specializations/BezierCurve.jl
@@ -32,11 +32,11 @@ calculating Jacobians that are used to calculate differential elements
 steep performance cost, especially for curves with a large number of control points.
 """
 function integral(
-    f,
-    curve::Meshes.BezierCurve,
-    rule::IntegrationRule;
-    alg::Meshes.BezierEvalMethod = Meshes.Horner(),
-    kwargs...
+        f,
+        curve::Meshes.BezierCurve,
+        rule::IntegrationRule;
+        alg::Meshes.BezierEvalMethod = Meshes.Horner(),
+        kwargs...
 )
     # Generate a _ParametricGeometry whose parametric function auto-applies the alg kwarg
     paramfunction(t) = _parametric(curve, t, alg)
@@ -45,7 +45,6 @@ function integral(
     # Integrate the _ParametricGeometry using the standard methods
     return _integral(f, param_curve, rule; kwargs...)
 end
-
 
 ################################################################################
 #                              Parametric

--- a/src/specializations/BezierCurve.jl
+++ b/src/specializations/BezierCurve.jl
@@ -40,7 +40,7 @@ function integral(
 )
     # Generate a _ParametricGeometry whose parametric function auto-applies the alg kwarg
     paramfunction(t) = _parametric(curve, t, alg)
-    param_curve = _ParametricGeometry(paramfunction, 1)
+    param_curve = _ParametricGeometry(paramfunction, Meshes.paramdim(curve))
 
     # Integrate the _ParametricGeometry using the standard methods
     return _integral(f, param_curve, rule; kwargs...)

--- a/src/specializations/Tetrahedron.jl
+++ b/src/specializations/Tetrahedron.jl
@@ -10,10 +10,10 @@
 ################################################################################
 
 function integral(
-    f::F,
-    tetrahedron::Meshes.Tetrahedron,
-    rule::IntegrationRule;
-    kwargs...
+        f::F,
+        tetrahedron::Meshes.Tetrahedron,
+        rule::IntegrationRule;
+        kwargs...
 ) where {F <: Function}
     # Generate a _ParametricGeometry whose parametric function domain spans [0,1]^3
     paramfunction(t1, t2, t3) = _parametric(tetrahedron, t1, t2, t3)

--- a/src/specializations/Tetrahedron.jl
+++ b/src/specializations/Tetrahedron.jl
@@ -17,7 +17,7 @@ function integral(
 )
     # Generate a _ParametricGeometry whose parametric function domain spans [0,1]^3
     paramfunction(t1, t2, t3) = _parametric(tetrahedron, t1, t2, t3)
-    tetra = _ParametricGeometry(paramfunction, 3)
+    tetra = _ParametricGeometry(paramfunction, Meshes.paramdim(tetrahedron))
 
     # Integrate the _ParametricGeometry using the standard methods
     return _integral(f, tetra, rule; kwargs...)

--- a/src/specializations/Tetrahedron.jl
+++ b/src/specializations/Tetrahedron.jl
@@ -10,11 +10,11 @@
 ################################################################################
 
 function integral(
-        f::F,
+        f,
         tetrahedron::Meshes.Tetrahedron,
         rule::IntegrationRule;
         kwargs...
-) where {F <: Function}
+)
     # Generate a _ParametricGeometry whose parametric function domain spans [0,1]^3
     paramfunction(t1, t2, t3) = _parametric(tetrahedron, t1, t2, t3)
     tetra = _ParametricGeometry(paramfunction, 3)

--- a/src/specializations/Triangle.jl
+++ b/src/specializations/Triangle.jl
@@ -98,3 +98,21 @@ end
 ################################################################################
 
 _has_analytical(::Type{T}) where {T <: Meshes.Triangle} = true
+
+################################################################################
+#                              Parametric
+################################################################################
+
+function _parametric(triangle::Meshes.Triangle, t1, t2)
+    if (t1 < 0 || t1 > 1) || (t2 < 0 || t2 > 1)
+        msg = "triangle(t1, t2) is not defined for (t1, t2) outside [0, 1]^2."
+        throw(DomainError((t1, t2), msg))
+    end
+
+    # Form a line segment between sides
+    a = triangle(0, t2)
+    b = triangle(t2, 0)
+    segment = Meshes.Segment(a, b)
+
+    return segment(t1)
+end

--- a/src/specializations/Triangle.jl
+++ b/src/specializations/Triangle.jl
@@ -98,7 +98,7 @@ function integral(
     ∫ = HCubature.hcubature(uintegrand, _zeros(FP, 2), (T(1), T(π / 2)), rule.kwargs...)[1]
 
     # Apply a linear domain-correction factor 0.5 ↦ area(triangle)
-    return 2 * Meshes.area(triangle) .* ∫
+    return 2 * Meshes.area(triangle) * integrandunits .* ∫
 end
 
 ################################################################################

--- a/src/specializations/_ParametricGeometry.jl
+++ b/src/specializations/_ParametricGeometry.jl
@@ -11,12 +11,12 @@ for more types that span surfaces and volumes, at which time this custom type wi
 no longer be required.
 
 # Fields
-- `fun::Function` - a parametric function: (ts...) -> Meshes.Point
+- `fun` - anything callable representing a parametric function: (ts...) -> Meshes.Point
 
 # Type Structure
 - `M <: Meshes.Manifold` - same usage as in `Meshes.Geometry{M, C}`
 - `C <: CoordRefSystems.CRS` - same usage as in `Meshes.Geometry{M, C}`
-- `F` - type of the callable integrand function
+- `F` - type of the callable parametric function
 - `Dim` - number of parametric dimensions
 """
 struct _ParametricGeometry{M <: Meshes.Manifold, C <: CRS, F, Dim} <:
@@ -38,7 +38,7 @@ Construct a `_ParametricGeometry` using a provided parametric function `fun` for
 with `dims` parametric dimensions.
 
 # Arguments
-- `fun::Function` - parametric function mapping `(ts...) -> Meshes.Point`
+- `fun` - anything callable representing a parametric function mapping `(ts...) -> Meshes.Point`
 - `dims::Int64` - number of parametric dimensions, i.e. `length(ts)`
 """
 function _ParametricGeometry(

--- a/src/specializations/_ParametricGeometry.jl
+++ b/src/specializations/_ParametricGeometry.jl
@@ -1,0 +1,63 @@
+"""
+    _ParametricGeometry <: Meshes.Primitive <: Meshes.Geometry
+
+_ParametricGeometry is used internally in MeshIntegrals.jl to behave like a generic wrapper
+for geometries with custom parametric functions. This type is used for transforming other
+geometries to enable integration over the standard rectangular `[0,1]^n` domain.
+
+Meshes.jl adopted a `ParametrizedCurve` type that performs a similar role as of `v0.51.20`,
+but only supports geometries with one parametric dimension. Support is additionally planned
+for more types that span surfaces and volumes, at which time this custom type will probably
+no longer be required.
+
+# Fields
+- `fun::Function` - a parametric function: (ts...) -> Meshes.Point
+
+# Type Structure
+- `M <: Meshes.Manifold` - same usage as in `Meshes.Geometry{M, C}`
+- `C <: CoordRefSystems.CRS` - same usage as in `Meshes.Geometry{M, C}`
+- `F` - type of the callable integrand function
+- `Dim` - number of parametric dimensions
+"""
+struct _ParametricGeometry{M <: Meshes.Manifold, C <: CRS, F, Dim} <:
+       Meshes.Primitive{M, C}
+    fun::F
+
+    function _ParametricGeometry{M, C}(
+            fun::F,
+            Dim::Int64
+    ) where {M <: Meshes.Manifold, C <: CRS, F}
+        return new{M, C, F, Dim}(fun)
+    end
+end
+
+"""
+    _ParametricGeometry(fun, dims)
+
+Construct a `_ParametricGeometry` using a provided parametric function `fun` for a geometry
+with `dims` parametric dimensions.
+
+# Arguments
+- `fun::Function` - parametric function mapping `(ts...) -> Meshes.Point`
+- `dims::Int64` - number of parametric dimensions, i.e. `length(ts)`
+"""
+function _ParametricGeometry(
+        fun::F,
+        Dim::Int64
+) where {F <: Function}
+    p = fun(_zeros(Dim)...)
+    return _ParametricGeometry{Meshes.manifold(p), Meshes.crs(p)}(fun, Dim)
+end
+
+# Allow a _ParametricGeometry to be called like a Geometry
+(g::_ParametricGeometry)(ts...) = g.fun(ts...)
+
+Meshes.paramdim(::_ParametricGeometry{M, C, F, Dim}) where {M, C, F, Dim} = Dim
+
+"""
+    _parametric(geometry::G, ts...) where {G <: Meshes.Geometry}
+
+Used in MeshIntegrals.jl for defining parametric functions that transform non-standard
+geometries into a form that can be integrated over the standard rectangular [0,1]^n limits.
+"""
+function _parametric end

--- a/src/specializations/_ParametricGeometry.jl
+++ b/src/specializations/_ParametricGeometry.jl
@@ -42,9 +42,9 @@ with `dims` parametric dimensions.
 - `dims::Int64` - number of parametric dimensions, i.e. `length(ts)`
 """
 function _ParametricGeometry(
-        fun::F,
+        fun,
         Dim::Int64
-) where {F <: Function}
+)
     p = fun(_zeros(Dim)...)
     return _ParametricGeometry{Meshes.manifold(p), Meshes.crs(p)}(fun, Dim)
 end

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -892,11 +892,11 @@ end
     pt_e = Point(1, 0, 0)
     triangle = Triangle(pt_e, pt_n, pt_w)
 
-    f(p) = 1.0
+    f(p) = 1.0u"A"
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    sol = Meshes.measure(triangle)
+    sol = Meshes.measure(triangle) * u"A"
     @test integral(f, triangle, GaussLegendre(100)) ≈ sol
     @test integral(f, triangle, GaussKronrod()) ≈ sol
     @test integral(f, triangle, HAdaptiveCubature()) ≈ sol

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -832,7 +832,7 @@ end
     @test_throws "not supported" volumeintegral(f, sphere)
 end
 
-@testitem "Meshes.Tetrahedron" tags=[:extended] setup=[Setup] begin
+@testitem "Meshes.Tetrahedron" setup=[Setup] begin
     pt_n = Point(0, 3, 0)
     pt_w = Point(-7, 0, 0)
     pt_e = Point(8, 0, 0)

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -833,31 +833,31 @@ end
 end
 
 @testitem "Meshes.Tetrahedron" tags=[:extended] setup=[Setup] begin
-    pt_n = Point(0, 1, 0)
-    pt_w = Point(-1, 0, 0)
-    pt_e = Point(1, 0, 0)
+    pt_n = Point(0, 3, 0)
+    pt_w = Point(-7, 0, 0)
+    pt_e = Point(8, 0, 0)
     ẑ = Vec(0, 0, 1)
     tetrahedron = Tetrahedron(pt_n, pt_w, pt_e, pt_n + ẑ)
 
-    f(p) = 1.0
+    f(p) = 1.0u"A"
     fv(p) = fill(f(p), 3)
 
     # Scalar integrand
-    sol = Meshes.measure(tetrahedron)
-    @test_throws "not supported" integral(f, tetrahedron, GaussLegendre(100))
-    @test integral(f, tetrahedron, GaussKronrod()) ≈ sol
-    @test_throws "not supported" integral(f, tetrahedron, HAdaptiveCubature())
+    sol = Meshes.measure(tetrahedron) * u"A"
+    @test integral(f, tetrahedron, GaussLegendre(100)) ≈ sol
+    @test_throws "not supported" integral(f, tetrahedron, GaussKronrod())
+    @test integral(f, tetrahedron, HAdaptiveCubature()) ≈ sol
 
     # Vector integrand
     vsol = fill(sol, 3)
-    @test_throws "not supported" integral(fv, tetrahedron, GaussLegendre(100))≈vsol
-    @test integral(fv, tetrahedron, GaussKronrod()) ≈ vsol
-    @test_throws "not supported" integral(fv, tetrahedron, HAdaptiveCubature())≈vsol
+    @test integral(fv, tetrahedron, GaussLegendre(100)) ≈ vsol
+    @test_throws "not supported" integral(fv, tetrahedron, GaussKronrod())
+    @test integral(fv, tetrahedron, HAdaptiveCubature()) ≈ vsol
 
     # Integral aliases
     @test_throws "not supported" lineintegral(f, tetrahedron)
     @test_throws "not supported" surfaceintegral(f, tetrahedron)
-    @test volumeintegral(f, tetrahedron, GaussKronrod()) ≈ sol
+    @test volumeintegral(f, tetrahedron, HAdaptiveCubature()) ≈ sol
 end
 
 @testitem "Meshes.Torus" setup=[Setup] begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -64,7 +64,6 @@ end
     # Ensure error is thrown for an out-of-bounds coordinate
     for ts in [(-0.5, 0.5), (0.5, -0.5), (1.5, 0.5), (0.5, 1.5)]
         @test_throws "not defined" _parametric(triangle, ts...)
-        
         # Tetrahedron forwards t1 and t2 to _parametric(::Triangle, ts...)
         @test_throws "not defined" _parametric(tetrahedron, ts..., 0)
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -23,29 +23,29 @@ end
     using MeshIntegrals: _has_analytical, _default_method, _guarantee_analytical
 
     # _has_analytical of instances
-    bezier = BezierCurve([Point(t, sin(t), 0.0) for t in range(-π, π, length = 361)])
-    @test _has_analytical(bezier) == true
+    triangle = Triangle(Point(0, 0, 0), Point(0, 1, 0), Point(1, 0, 0))
+    @test _has_analytical(triangle) == true
     sphere = Sphere(Point(0, 0, 0), 1.0)
     @test _has_analytical(sphere) == false
 
+    # _default_method
+    @test _default_method(Meshes.Triangle) isa Analytical
+    @test _default_method(triangle) isa Analytical
+    @test _default_method(Meshes.Sphere) isa FiniteDifference
+    @test _default_method(sphere) isa FiniteDifference
+
     # _has_analytical of types
-    @test _has_analytical(Meshes.BezierCurve) == true
+    @test _has_analytical(Meshes.BezierCurve) == false
     @test _has_analytical(Meshes.Line) == true
     @test _has_analytical(Meshes.Plane) == true
     @test _has_analytical(Meshes.Ray) == true
     @test _has_analytical(Meshes.Sphere) == false
-    @test _has_analytical(Meshes.Tetrahedron) == true
+    @test _has_analytical(Meshes.Tetrahedron) == false
     @test _has_analytical(Meshes.Triangle) == true
 
     # _guarantee_analytical
     @test _guarantee_analytical(Meshes.Line, Analytical()) === nothing
     @test_throws "Analytical" _guarantee_analytical(Meshes.Line, FiniteDifference())
-
-    # _default_method
-    @test _default_method(Meshes.BezierCurve) isa Analytical
-    @test _default_method(bezier) isa Analytical
-    @test _default_method(Meshes.Sphere) isa FiniteDifference
-    @test _default_method(sphere) isa FiniteDifference
 
     # FiniteDifference
     @test FiniteDifference().ε ≈ 1e-6

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -66,6 +66,6 @@ end
     end
 
     for t3 in [-0.5, 1.5]
-        @test_throws "not defind" _parametric(tetrahedron, 0, 0, t3)
+        @test_throws "not defined" _parametric(tetrahedron, 0, 0, t3)
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -61,10 +61,15 @@ end
     triangle = Triangle(pt_n, pt_w, pt_e)
     tetrahedron = Tetrahedron(pt_n, pt_w, pt_e, pt_n + ẑ)
 
+    # Ensure error is thrown for an out-of-bounds coordinate
     for ts in [(-0.5, 0.5), (0.5, -0.5), (1.5, 0.5), (0.5, 1.5)]
         @test_throws "not defined" _parametric(triangle, ts...)
+        
+        # Tetrahedron forwards t1 and t2 to _parametric(::Triangle, ts...)
+        @test_throws "not defined" _parametric(tetrahedron, ts..., 0)
     end
 
+    # Ensue error is thrown for an out-of-bounds third coordinate
     for t3 in [-0.5, 1.5]
         @test_throws "not defined" _parametric(tetrahedron, 0, 0, t3)
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -52,7 +52,7 @@ end
 end
 
 @testitem "_ParametricGeometry" setup=[Setup] begin
-    using Meshes: _parametric
+    using MeshIntegrals: _parametric
 
     pt_n = Point(0, 3, 0)
     pt_w = Point(-7, 0, 0)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -50,3 +50,22 @@ end
     # FiniteDifference
     @test FiniteDifference().ε ≈ 1e-6
 end
+
+@testitem "_ParametricGeometry" setup=[Setup] begin
+    using Meshes: _parametric
+
+    pt_n = Point(0, 3, 0)
+    pt_w = Point(-7, 0, 0)
+    pt_e = Point(8, 0, 0)
+    ẑ = Vec(0, 0, 1)
+    triangle = Triangle(pt_n, pt_w, pt_e)
+    tetrahedron = Tetrahedron(pt_n, pt_w, pt_e, pt_n + ẑ)
+
+    for ts in [(-0.5, 0.5), (0.5, -0.5), (1.5, 0.5), (0.5, 1.5)]
+        @test_throws "not defined" _parametric(triangle, ts...)
+    end
+
+    for t3 in [-0.5, 1.5]
+        @test_throws "not defind" _parametric(tetrahedron, 0, 0, t3)
+    end
+end


### PR DESCRIPTION
## Changes
- Implements an internal `_ParametricGeometry <: Meshes.Geometry` type to serve as a simple wrapper for custom parametric functions `_parametric(geometry, ts...)`.
- Uses this new geometry type to implement new integral methods for `BezierCurve` and `Tetrahedron` geometries, closing #40. This achieved an 80x performance improvement for integrals over a `BezierCurve`.
- Removes the `jacobian(::BezierCurve, ts, ::Analytical)` method - performance was inferior to the generic `FiniteDifference` method.
- Remove `extended` tag from `Tetrahedron` tests now that they return in reasonable CI timespans.
- Updated a remnant usage of `Base.zeros` to `_zeros`, providing `HAdaptiveCubature` integrals with an up to 20% performance improvement.

## Discussion
This is a follow-up to #131, where the scope of changes had become over-extended. Some of those changes were implemented separately in other PR’s.

I’ve chosen not to also tackle other specialization geometries yet, since those seemed to suffer performance penalties. Those implementations are left for future work.