### PR TITLE
Rename _default_method and absorb _gausslegendre

### DIFF
--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -52,7 +52,7 @@ function jacobian(
         geometry::G,
         ts::Union{AbstractVector{T}, Tuple{T, Vararg{T}}}
 ) where {G <: Geometry, T <: AbstractFloat}
-    return jacobian(geometry, ts, _default_method(G))
+    return jacobian(geometry, ts, _default_diff_method(G))
 end
 
 function jacobian(
@@ -107,7 +107,7 @@ possible and finite difference approximations otherwise.
 function differential(
         geometry::G,
         ts::Union{AbstractVector{T}, Tuple{T, Vararg{T}}},
-        diff_method::DifferentiationMethod = _default_method(G)
+        diff_method::DifferentiationMethod = _default_diff_method(G)
 ) where {G <: Geometry, T <: AbstractFloat}
     J = Iterators.map(_KVector, jacobian(geometry, ts, diff_method))
     return LinearAlgebra.norm(foldl(∧, J))

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -76,8 +76,8 @@ function _integral(
 
     # Get Gauss-Legendre nodes and weights of type FP for a region [-1,1]ᴺ
     xs, ws = FastGaussQuadrature.gausslegendre(rule.n)
-    xsFP = Iterator.map(FP, xs)
-    wsFP = Iterator.map(FP, ws)
+    xsFP = Iterators.map(FP, xs)
+    wsFP = Iterators.map(FP, ws)
     weight_grid = Iterators.product(ntuple(Returns(wsFP), N)...)
     node_grid = Iterators.product(ntuple(Returns(xsFP), N)...)
 

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -84,9 +84,9 @@ function _integral(
     # Domain transformation: x [-1,1] ↦ t [0,1]
     t(x) = (1 // 2) * x + (1 // 2)
 
-    function integrand((weights, nodes); N=N)
+    function integrand((weights, nodes))
         # Transforms nodes/xs, store in an NTuple 
-        ts = ntuple(i -> t(nodes[i]), N)
+        ts = ntuple(i -> t(nodes[i]), length(nodes))
         # Integrand function
         prod(weights) * f(geometry(ts...)) * differential(geometry, ts, diff_method)
     end

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -75,15 +75,15 @@ function _integral(
     N = Meshes.paramdim(geometry)
 
     # Get Gauss-Legendre nodes and weights of type FP for a region [-1,1]ᴺ
-    xs, ws = FastGaussQuadrature.gausslegendre(N)
-    weights = Iterators.product(ntuple(Returns(FP.(ws)), N)...)
-    nodes = Iterators.product(ntuple(Returns(FP.(xs)), N)...)
+    xs, ws = FastGaussQuadrature.gausslegendre(rule.N)
+    weights = Iterators.product(ntuple(Returns(FP.(ws)), N)...) # TODO Iterators
+    nodes = Iterators.product(ntuple(Returns(FP.(xs)), N)...) # TODO Iterators
 
     # Domain transformation: x [-1,1] ↦ t [0,1]
     t(x) = (1 // 2) * x + (1 // 2)
 
     function integrand((weights, nodes))
-        ts = t.(nodes)
+        ts = t.(nodes)  # TODO Iterators
         prod(weights) * f(geometry(ts...)) * differential(geometry, ts, diff_method)
     end
 

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -86,7 +86,7 @@ function _integral(
 
     function integrand((weights, nodes))
         # Transforms nodes/xs, store in an NTuple 
-        ts = ntuple(i -> t(nodes[i]), length(nodes))
+        ts = ntuple(i -> t(nodes[i]), rule.n)
         # Integrand function
         prod(weights) * f(geometry(ts...)) * differential(geometry, ts, diff_method)
     end

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -76,10 +76,8 @@ function _integral(
 
     # Get Gauss-Legendre nodes and weights of type FP for a region [-1,1]ᴺ
     xs, ws = FastGaussQuadrature.gausslegendre(N)
-    xsT = Iterators.map(FP, xs)
-    wsT = Iterators.map(FP, ws)
-    weights = Iterators.product(ntuple(Returns(wsT), N)...)
-    nodes = Iterators.product(ntuple(Returns(xsT), N)...)
+    weights = Iterators.product(ntuple(Returns(FP.(ws)), N)...)
+    nodes = Iterators.product(ntuple(Returns(FP.(xs)), N)...)
 
     # Domain transformation: x [-1,1] ↦ t [0,1]
     t(x) = (1 // 2) * x + (1 // 2)

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -42,7 +42,7 @@ function _integral(
         geometry,
         rule::GaussKronrod;
         FP::Type{T} = Float64,
-        diff_method::DM = _default_method(geometry)
+        diff_method::DM = _default_diff_method(geometry)
 ) where {DM <: DifferentiationMethod, T <: AbstractFloat}
     # Implementation depends on number of parametric dimensions over which to integrate
     N = Meshes.paramdim(geometry)
@@ -70,7 +70,7 @@ function _integral(
         geometry,
         rule::GaussLegendre;
         FP::Type{T} = Float64,
-        diff_method::DM = _default_method(geometry)
+        diff_method::DM = _default_diff_method(geometry)
 ) where {DM <: DifferentiationMethod, T <: AbstractFloat}
     N = Meshes.paramdim(geometry)
 
@@ -96,7 +96,7 @@ function _integral(
         geometry,
         rule::HAdaptiveCubature;
         FP::Type{T} = Float64,
-        diff_method::DM = _default_method(geometry)
+        diff_method::DM = _default_diff_method(geometry)
 ) where {DM <: DifferentiationMethod, T <: AbstractFloat}
     N = Meshes.paramdim(geometry)
 

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -74,10 +74,12 @@ function _integral(
 ) where {DM <: DifferentiationMethod, T <: AbstractFloat}
     N = Meshes.paramdim(geometry)
 
-    # Get Gauss-Legendre nodes and weights for a region [-1,1]^N
-    xs, ws = _gausslegendre(FP, rule.n)
-    weights = Iterators.product(ntuple(Returns(ws), N)...)
-    nodes = Iterators.product(ntuple(Returns(xs), N)...)
+    # Get Gauss-Legendre nodes and weights of type FP for a region [-1,1]ᴺ
+    xs, ws = FastGaussQuadrature.gausslegendre(N)
+    xsT = Iterator.map(FP, xs)
+    wsT = Iterator.map(FP, ws)
+    weights = Iterators.product(ntuple(Returns(wsT), N)...)
+    nodes = Iterators.product(ntuple(Returns(xsT), N)...)
 
     # Domain transformation: x [-1,1] ↦ t [0,1]
     t(x) = (1 // 2) * x + (1 // 2)

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -75,7 +75,7 @@ function _integral(
     N = Meshes.paramdim(geometry)
 
     # Get Gauss-Legendre nodes and weights of type FP for a region [-1,1]ᴺ
-    xs, ws = FastGaussQuadrature.gausslegendre(rule.N)
+    xs, ws = FastGaussQuadrature.gausslegendre(rule.n)
     weights = Iterators.product(ntuple(Returns(FP.(ws)), N)...) # TODO Iterators
     nodes = Iterators.product(ntuple(Returns(FP.(xs)), N)...) # TODO Iterators
 
@@ -83,7 +83,9 @@ function _integral(
     t(x) = (1 // 2) * x + (1 // 2)
 
     function integrand((weights, nodes))
-        ts = t.(nodes)  # TODO Iterators
+        # Transforms nodes/xs, store in an NTuple 
+        ts = ntuple(i -> t(nodes[i]), length(nodes))
+        # Integrand function
         prod(weights) * f(geometry(ts...)) * differential(geometry, ts, diff_method)
     end
 

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -76,8 +76,8 @@ function _integral(
 
     # Get Gauss-Legendre nodes and weights of type FP for a region [-1,1]ᴺ
     xs, ws = FastGaussQuadrature.gausslegendre(N)
-    xsT = Iterator.map(FP, xs)
-    wsT = Iterator.map(FP, ws)
+    xsT = Iterators.map(FP, xs)
+    wsT = Iterators.map(FP, ws)
     weights = Iterators.product(ntuple(Returns(wsT), N)...)
     nodes = Iterators.product(ntuple(Returns(xsT), N)...)
 

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -86,7 +86,7 @@ function _integral(
 
     function integrand((weights, nodes))
         # Transforms nodes/xs, store in an NTuple 
-        ts = ntuple(i -> t(nodes[i]), rule.n)
+        ts = ntuple(i -> t(nodes[i]), N)
         # Integrand function
         prod(weights) * f(geometry(ts...)) * differential(geometry, ts, diff_method)
     end

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -84,7 +84,7 @@ function _integral(
     # Domain transformation: x [-1,1] ↦ t [0,1]
     t(x) = (1 // 2) * x + (1 // 2)
 
-    function integrand((weights, nodes))
+    function integrand((weights, nodes); N=N)
         # Transforms nodes/xs, store in an NTuple 
         ts = ntuple(i -> t(nodes[i]), N)
         # Integrand function

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -76,8 +76,8 @@ function _integral(
 
     # Get Gauss-Legendre nodes and weights of type FP for a region [-1,1]ᴺ
     xs, ws = FastGaussQuadrature.gausslegendre(rule.n)
-    weights = Iterators.product(ntuple(Returns(FP.(ws)), N)...) # TODO Iterators
-    nodes = Iterators.product(ntuple(Returns(FP.(xs)), N)...) # TODO Iterators
+    weight_grid = Iterators.product(ntuple(Returns(FP.(ws)), N)...) # TODO Iterators
+    node_grid = Iterators.product(ntuple(Returns(FP.(xs)), N)...) # TODO Iterators
 
     # Domain transformation: x [-1,1] ↦ t [0,1]
     t(x) = (1 // 2) * x + (1 // 2)
@@ -89,7 +89,7 @@ function _integral(
         prod(weights) * f(geometry(ts...)) * differential(geometry, ts, diff_method)
     end
 
-    return (1 // (2^N)) .* sum(integrand, zip(weights, nodes))
+    return (1 // (2^N)) .* sum(integrand, zip(weight_grid, node_grid))
 end
 
 # HAdaptiveCubature

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -76,8 +76,10 @@ function _integral(
 
     # Get Gauss-Legendre nodes and weights of type FP for a region [-1,1]ᴺ
     xs, ws = FastGaussQuadrature.gausslegendre(rule.n)
-    weight_grid = Iterators.product(ntuple(Returns(FP.(ws)), N)...) # TODO Iterators
-    node_grid = Iterators.product(ntuple(Returns(FP.(xs)), N)...) # TODO Iterators
+    xsFP = Iterator.map(FP, xs)
+    wsFP = Iterator.map(FP, ws)
+    weight_grid = Iterators.product(ntuple(Returns(wsFP), N)...)
+    node_grid = Iterators.product(ntuple(Returns(xsFP), N)...)
 
     # Domain transformation: x [-1,1] ↦ t [0,1]
     t(x) = (1 // 2) * x + (1 // 2)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,14 +27,14 @@ _ones(N::Int) = _ones(Float64, N)
 ################################################################################
 
 # Return the default DifferentiationMethod instance for a particular geometry type
-function _default_method(
+function _default_diff_method(
         g::Type{G}
 ) where {G <: Geometry}
     return FiniteDifference()
 end
 
 # Return the default DifferentiationMethod instance for a particular geometry instance
-_default_method(g::G) where {G <: Geometry} = _default_method(G)
+_default_diff_method(g::G) where {G <: Geometry} = _default_diff_method(G)
 
 ################################################################################
 #                        CliffordNumbers and Units

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,25 +2,11 @@
 #                           Misc. Internal Tools
 ################################################################################
 
-# Calculate Gauss-Legendre nodes/weights and convert to type T
-function _gausslegendre(T, n)
-    xs, ws = FastGaussQuadrature.gausslegendre(n)
-    return T.(xs), T.(ws)
-end
-
 # Common error message structure
 function _error_unsupported_combination(geometry, rule)
     msg = "Integrating a $geometry using a $rule rule not supported."
     throw(ArgumentError(msg))
 end
-
-# Return an NTuple{N, T} of zeros; same interface as Base.zeros() but faster
-_zeros(T::DataType, N::Int64) = ntuple(_ -> zero(T), N)
-_zeros(N::Int) = _zeros(Float64, N)
-
-# Return an NTuple{N, T} of ones; same interface as Base.ones() but faster
-_ones(T::DataType, N::Int64) = ntuple(_ -> one(T), N)
-_ones(N::Int) = _ones(Float64, N)
 
 ################################################################################
 #                           DifferentiationMethod
@@ -37,15 +23,52 @@ end
 _default_diff_method(g::G) where {G <: Geometry} = _default_diff_method(G)
 
 ################################################################################
-#                        CliffordNumbers and Units
+#                           Numerical Tools
 ################################################################################
 
-# Meshes.Vec -> Unitful.Quantity{CliffordNumber.KVector}
+# Calculate Gauss-Legendre nodes/weights and convert to type T
+"""
+    _gausslegendre(T, n)
+
+Return FastGaussQuadrature.gausslegendre(n) in type T.
+"""
+function _gausslegendre(T, n)
+    xs, ws = FastGaussQuadrature.gausslegendre(n)
+    return T.(xs), T.(ws)
+end
+
+"""
+    _KVector(v::Meshes.Vec) -> Unitful.Quantity{CliffordNumbers.KVector}
+
+Convert a `Vec` to a Unitful KVector.
+"""
 function _KVector(v::Meshes.Vec{Dim, T}) where {Dim, T}
     ucoords = Iterators.map(Unitful.ustrip, v.coords)
     return CliffordNumbers.KVector{1, VGA(Dim)}(ucoords...) * _units(v)
 end
 
-# Extract the length units used by the CRS of a Geometry
+"""
+    _units(geometry)
+
+Return the Unitful units associated with a particular `geometry`.
+"""
 _units(::Geometry{M, CRS}) where {M, CRS} = Unitful.unit(CoordRefSystems.lentype(CRS))
 _units(::Meshes.Vec{Dim, T}) where {Dim, T} = Unitful.unit(T)
+
+"""
+    _zeros(T = Float64, N)
+
+Return an `NTuple{N, T}` filled with zeros. This method avoids allocating an array, which
+happens when using `Base.zeros`.
+"""
+_zeros(T::DataType, N::Int64) = ntuple(_ -> zero(T), N)
+_zeros(N::Int) = _zeros(Float64, N)
+
+"""
+    _ones(T = Float64, N)
+
+Return an `NTuple{N, T}` filled with ones. This method avoids allocating an array, which
+happens when using `Base.ones`.
+"""
+_ones(T::DataType, N::Int64) = ntuple(_ -> one(T), N)
+_ones(N::Int) = _ones(Float64, N)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,7 +39,7 @@ end
 """
     _units(geometry)
 
-Return the Unitful units associated with a particular `geometry`.
+Return the Unitful.jl units associated with a particular `geometry`.
 """
 _units(::Geometry{M, CRS}) where {M, CRS} = Unitful.unit(CoordRefSystems.lentype(CRS))
 _units(::Meshes.Vec{Dim, T}) where {Dim, T} = Unitful.unit(T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,17 +26,6 @@ _default_diff_method(g::G) where {G <: Geometry} = _default_diff_method(G)
 #                           Numerical Tools
 ################################################################################
 
-# Calculate Gauss-Legendre nodes/weights and convert to type T
-"""
-    _gausslegendre(T, n)
-
-Return FastGaussQuadrature.gausslegendre(n) in type T.
-"""
-function _gausslegendre(T, n)
-    xs, ws = FastGaussQuadrature.gausslegendre(n)
-    return T.(xs), T.(ws)
-end
-
 """
     _KVector(v::Meshes.Vec) -> Unitful.Quantity{CliffordNumbers.KVector}
 

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -66,9 +66,7 @@ end
 end
 
 @testitem "Meshes.BezierCurve" setup=[Setup] begin
-    curve = BezierCurve(
-        [Point(t * u"m", sin(t) * u"m", 0.0u"m") for t in range(-pi, pi, length = 361)]
-    )
+    curve = BezierCurve([Point(t, sin(t), 0) for t in range(-pi, pi, length = 361)])
 
     function f(p::P) where {P <: Meshes.Point}
         ux = ustrip(p.coords.x)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -22,7 +22,7 @@ end
 @testitem "DifferentiationMethod" setup=[Setup] begin
     using MeshIntegrals: _default_diff_method
 
-    # _default_method
+    # _default_diff_method
     sphere = Sphere(Point(0, 0, 0), 1.0)
     @test _default_diff_method(Meshes.Sphere) isa FiniteDifference
     @test _default_diff_method(sphere) isa FiniteDifference

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -20,15 +20,12 @@
 end
 
 @testitem "DifferentiationMethod" setup=[Setup] begin
-    using MeshIntegrals: _default_method
-
-    # Test geometries
-    sphere = Sphere(Point(0, 0, 0), 1.0)
-    triangle = Triangle(Point(0, 0, 0), Point(0, 1, 0), Point(1, 0, 0))
+    using MeshIntegrals: _default_diff_method
 
     # _default_method
-    @test _default_method(Meshes.Sphere) isa FiniteDifference
-    @test _default_method(sphere) isa FiniteDifference
+    sphere = Sphere(Point(0, 0, 0), 1.0)
+    @test _default_diff_method(Meshes.Sphere) isa FiniteDifference
+    @test _default_diff_method(sphere) isa FiniteDifference
 
     # FiniteDifference
     @test FiniteDifference().ε ≈ 1e-6


### PR DESCRIPTION
## Changes
- Renames `_default_method` to `_default_diff_method` (#146)
- Absorbed `_gausslegendre` into only remaining `GaussLegendre` integral method
  - This change improved performance up to about 30% for `GaussLegendre` integrals.
- Reorganized `utils.jl` functions and added docstrings