### PR TITLE
Unify spelling of "parametrize"

### DIFF
--- a/src/specializations/BezierCurve.jl
+++ b/src/specializations/BezierCurve.jl
@@ -27,7 +27,7 @@ Like [`integral`](@ref) but integrates along the domain defined by `curve`.
 - `diff_method::DifferentiationMethod = Analytical()`: the method to use for
 calculating Jacobians that are used to calculate differential elements
 - `FP = Float64`: the floating point precision desired
-- `alg = Meshes.Horner()`:  the method to use for parameterizing `curve`. Alternatively,
+- `alg = Meshes.Horner()`:  the method to use for parametrizing `curve`. Alternatively,
 `alg=Meshes.DeCasteljau()` can be specified for increased accuracy, but comes with a
 steep performance cost, especially for curves with a large number of control points.
 """

--- a/src/specializations/ConeSurface.jl
+++ b/src/specializations/ConeSurface.jl
@@ -3,7 +3,7 @@
 #
 # Why Specialized?
 #   The parametric function that Meshes.jl currently implements for ConeSurface
-#   only parameterizes the rounded walls of the cone, but this Geometry surface is
+#   only parametrizes the rounded walls of the cone, but this Geometry surface is
 #   defined as including the circular base surface as well. These methods simply
 #   integrate both the base and walls and return the sum of the two integrals.
 ################################################################################
@@ -14,7 +14,7 @@ function integral(
         rule::I;
         kwargs...
 ) where {I <: IntegrationRule}
-    # The generic method only parameterizes the sides
+    # The generic method only parametrizes the sides
     sides = _integral(f, cone, rule; kwargs...)
 
     # Integrate the Disk at the base

--- a/src/specializations/CylinderSurface.jl
+++ b/src/specializations/CylinderSurface.jl
@@ -3,7 +3,7 @@
 #
 # Why Specialized?
 #   The parametric function that Meshes.jl currently implements for CylinderSurface
-#   only parameterizes the rounded walls, but this Geometry surface is defined as
+#   only parametrizes the rounded walls, but this Geometry surface is defined as
 #   including the top and bottom circular base surfaces as well. These methods
 #   simply integrate the base and walls and return the sum of the three integrals.
 ################################################################################
@@ -14,7 +14,7 @@ function integral(
         rule::I;
         kwargs...
 ) where {I <: IntegrationRule}
-    # The generic method only parameterizes the sides
+    # The generic method only parametrizes the sides
     sides = _integral(f, cyl, rule; kwargs...)
 
     # Integrate the Disk at the top

--- a/src/specializations/FrustumSurface.jl
+++ b/src/specializations/FrustumSurface.jl
@@ -3,7 +3,7 @@
 #
 # Why Specialized?
 #   The parametric function that Meshes.jl currently implements for FrustumSurface
-#   only parameterizes the rounded walls, but this Geometry surface is defined as
+#   only parametrizes the rounded walls, but this Geometry surface is defined as
 #   including the truncated top and bottom surfaces as well. These methods simply
 #   integrate both the walls and the ends and return the sum of the these integrals.
 ################################################################################
@@ -14,7 +14,7 @@ function integral(
         rule::I;
         kwargs...
 ) where {I <: IntegrationRule}
-    # The generic method only parameterizes the sides
+    # The generic method only parametrizes the sides
     sides = _integral(f, frust, rule; kwargs...)
 
     # Integrate the Disks at the top and bottom

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -545,7 +545,7 @@ end
     if pkgversion(Meshes) >= v"0.51.20"
         using CoordRefSystems: Polar
 
-        # Parameterize a circle centered on origin with specified radius
+        # Parametrize a circle centered on origin with specified radius
         radius = 4.4
         curve_cart = ParametrizedCurve(
             t -> Point(radius * cos(t), radius * sin(t)), (0.0, 2π))


### PR DESCRIPTION
## Changes
- Changes spelling of words like "parameterize" to words like "parametrize", closing #143.