### PR TITLE
Use `hcubature_buffer` for decomposed geometries

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -72,10 +72,9 @@ SUITE["Specializations"] = let s = BenchmarkGroup()
     end
     =#
     for rule in spec.rules, geometry in spec.geometries_exp
-        @info (rule, geometry)
         geometry_name = nameof(typeof(geometry))
         rule_name = nameof(typeof(rule))
-        s[geometry_name, r.name] = @benchmarkable integral($spec.f_exp, geometry, r.rule)
+        s[geometry_name, rule_name] = @benchmarkable integral($spec.f_exp, geometry, rule)
     end
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -59,19 +59,22 @@ spec = (
         ray = Ray(Point(0, 0, 0), Vec(0, 0, 1))
     ),
     rules = (
-            ( name = "GaussLegendre", rule = GaussLegendre(100) ),
-            ( name = "HAdaptiveCubature", rule = HAdaptiveCubature() )
+        GaussLegendre(100),
+        HAdaptiveCubature()
     )
 )
 
 SUITE["Specializations"] = let s = BenchmarkGroup()
-    s[]
+    #=
     for r in spec.rules, geometry in spec.geometries
         geometry_name = nameof(typeof(geometry))
         s[geometry_name, r.name] = @benchmarkable integral($spec.f, geometry, r.rule)
     end
-    for r in spec.rules, geometry in spec.geometries_exp
+    =#
+    for rule in spec.rules, geometry in spec.geometries_exp
+        @info (rule, geometry)
         geometry_name = nameof(typeof(geometry))
+        rule_name = nameof(typeof(rule))
         s[geometry_name, r.name] = @benchmarkable integral($spec.f_exp, geometry, r.rule)
     end
     s

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -67,11 +67,11 @@ spec = (
 SUITE["Specializations"] = let s = BenchmarkGroup()
     s[]
     for r in spec.rules, geometry in spec.geometries
-        geometry_name = nameof(typeof(geometry.name))
+        geometry_name = nameof(typeof(geometry))
         s[geometry_name, r.name] = @benchmarkable integral($spec.f, geometry, r.rule)
     end
     for r in spec.rules, geometry in spec.geometries_exp
-        geometry_name = nameof(typeof(geometry.name))
+        geometry_name = nameof(typeof(geometry))
         s[geometry_name, r.name] = @benchmarkable integral($spec.f_exp, geometry, r.rule)
     end
     s

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -16,20 +16,19 @@ integrands = (
     (name = "Vector", f = p -> fill(norm(to(p)), 3))
 )
 rules = (
-    (name = "GaussLegendre", rule = GaussLegendre(100)),
-    (name = "GaussKronrod", rule = GaussKronrod()),
-    (name = "HAdaptiveCubature", rule = HAdaptiveCubature())
+    GaussLegendre(100),
+    GaussKronrod(),
+    HAdaptiveCubature()
 )
 geometries = (
-    (name = "Segment", item = Segment(Point(0, 0, 0), Point(1, 1, 1))),
-    (name = "Sphere", item = Sphere(Point(0, 0, 0), 1.0))
+    Segment(Point(0, 0, 0), Point(1, 1, 1)),
+    Sphere(Point(0, 0, 0), 1.0)
 )
 
 SUITE["Integrals"] = let s = BenchmarkGroup()
     for (int, rule, geometry) in Iterators.product(integrands, rules, geometries)
-        n1 = geometry.name
-        n2 = "$(int.name) $(rule.name)"
-        s[n1][n2] = @benchmarkable integral($int.f, $geometry.item, $rule.rule)
+        name = "$(nameof(typeof(geometry))), $(int.name), $(nameof(typeof(rule)))"
+        s[name] = @benchmarkable integral($int.f, $geometry.item, $rule.rule)
     end
     s
 end
@@ -65,16 +64,16 @@ spec = (
 )
 
 SUITE["Specializations"] = let s = BenchmarkGroup()
-    #=
-    for r in spec.rules, geometry in spec.geometries
-        geometry_name = nameof(typeof(geometry))
-        s[geometry_name, r.name] = @benchmarkable integral($spec.f, geometry, r.rule)
+    # Benchmark most specialization geometries
+    for rule in spec.rules, geometry in spec.geometries
+        name = "$(nameof(typeof(geometry))), Scalar, $(nameof(typeof(rule)))"
+        s[name] = @benchmarkable integral($spec.f, $geometry, $rule)
     end
-    =#
+
+    # Geometries that span an infinite domain use exp function instead
     for rule in spec.rules, geometry in spec.geometries_exp
-        geometry_name = nameof(typeof(geometry))
-        rule_name = nameof(typeof(rule))
-        s[geometry_name, rule_name] = @benchmarkable integral($spec.f_exp, $geometry, $rule)
+        name = "$(nameof(typeof(geometry))), Scalar, $(nameof(typeof(rule)))"
+        s[name] = @benchmarkable integral($spec.f_exp, $geometry, $rule)
     end
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -74,7 +74,7 @@ SUITE["Specializations"] = let s = BenchmarkGroup()
     for rule in spec.rules, geometry in spec.geometries_exp
         geometry_name = nameof(typeof(geometry))
         rule_name = nameof(typeof(rule))
-        s[geometry_name, rule_name] = @benchmarkable integral($spec.f_exp, geometry, rule)
+        s[geometry_name, rule_name] = @benchmarkable integral($spec.f_exp, $geometry, $rule)
     end
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -67,10 +67,12 @@ spec = (
 SUITE["Specializations"] = let s = BenchmarkGroup()
     s[]
     for r in spec.rules, geometry in spec.geometries
-        s[geometry.name, r.name] = @benchmarkable integral($spec.f, geometry, r.rule)
+        geometry_name = nameof(typeof(geometry.name))
+        s[geometry_name, r.name] = @benchmarkable integral($spec.f, geometry, r.rule)
     end
     for r in spec.rules, geometry in spec.geometries_exp
-        s[geometry.name, r.name] = @benchmarkable integral($spec.f_exp, geometry, r.rule)
+        geometry_name = nameof(typeof(geometry.name))
+        s[geometry_name, r.name] = @benchmarkable integral($spec.f_exp, geometry, r.rule)
     end
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -21,6 +21,9 @@ rules = (
     HAdaptiveCubature()
 )
 geometries = (
+    let ẑ = Vec(0, 0, 1)
+        CylinderSurface(Plane(Point(0, 0, 0), ẑ), Plane(Point(0, 0, 3), ẑ), 2.5)
+    end,
     Segment(Point(0, 0, 0), Point(1, 1, 1)),
     Sphere(Point(0, 0, 0), 1.0)
 )

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -28,7 +28,7 @@ geometries = (
 SUITE["Integrals"] = let s = BenchmarkGroup()
     for (int, rule, geometry) in Iterators.product(integrands, rules, geometries)
         name = "$(nameof(typeof(geometry))), $(int.name), $(nameof(typeof(rule)))"
-        s[name] = @benchmarkable integral($int.f, $geometry.item, $rule.rule)
+        s[name] = @benchmarkable integral($int.f, $geometry, $rule)
     end
     s
 end

--- a/src/specializations/Rope.jl
+++ b/src/specializations/Rope.jl
@@ -42,12 +42,12 @@ function integral(
     rule::HAdaptiveCubature;
     FP::Type{T} = Float64,
     kwargs...
-)
+) where {T <: AbstractFloat}
     # Append a buffer to the given rule
     buffer = HCubature.hcubature_buffer(f, _zeros(FP, 1), _ones(FP, 2))
     rule = HAdaptiveCubature(rule.kwargs..., buffer = buffer)
 
     # Convert the Rope into Segments, sum the integrals of those
-    _subintegral(seg) = _integral(f, seg, rule; FP = FP, rule.kwargs...)
+    _subintegral(seg) = _integral(f, seg, rule; FP = FP, kwargs...)
     return sum(_subintegral, Meshes.segments(rope))
 end

--- a/src/specializations/Rope.jl
+++ b/src/specializations/Rope.jl
@@ -36,6 +36,7 @@ function integral(
     return sum(segment -> integral(f, segment, rule; kwargs...), Meshes.segments(rope))
 end
 
+# Use HCubature.hcubature_buffer to reduce allocations
 function integral(
     f,
     rope::Meshes.Rope,
@@ -44,7 +45,7 @@ function integral(
     kwargs...
 ) where {T <: AbstractFloat}
     # Geometry information
-    N = Meshes.paramdim(geometry)
+    N = Meshes.paramdim(rope)
     segments = Meshes.segments(rope)
 
     # Use a sample integrand to develop and append a buffer to the given rule

--- a/src/specializations/Rope.jl
+++ b/src/specializations/Rope.jl
@@ -44,7 +44,7 @@ function integral(
     kwargs...
 ) where {T <: AbstractFloat}
     # Append a buffer to the given rule
-    buffer = HCubature.hcubature_buffer(f, _zeros(FP, 1), _ones(FP, 2))
+    buffer = HCubature.hcubature_buffer(f, _zeros(FP, 1), _ones(FP, 1))
     rule = HAdaptiveCubature(rule.kwargs..., buffer = buffer)
 
     # Convert the Rope into Segments, sum the integrals of those

--- a/src/specializations/Rope.jl
+++ b/src/specializations/Rope.jl
@@ -49,7 +49,8 @@ function integral(
     segments = Meshes.segments(rope)
 
     # Use a sample integrand to develop and append a buffer to the given rule
-    integrand(ts) = f(segments[1](ts...)) * differential(segments[1], ts)
+    sample = first(segments)
+    integrand(ts) = f(sample(ts...)) * differential(sample, ts)
     uintegrand(ts) = Unitful.ustrip.(integrand(ts))
     buffer = HCubature.hcubature_buffer(uintegrand, _zeros(FP, N), _ones(FP, N))
     rule = HAdaptiveCubature(rule.kwargs..., buffer = buffer)

--- a/src/specializations/Rope.jl
+++ b/src/specializations/Rope.jl
@@ -35,3 +35,19 @@ function integral(
     # Convert the Rope into Segments, sum the integrals of those
     return sum(segment -> integral(f, segment, rule; kwargs...), Meshes.segments(rope))
 end
+
+function integral(
+    f,
+    rope::Meshes.Rope,
+    rule::HAdaptiveCubature;
+    FP::Type{T} = Float64,
+    kwargs...
+)
+    # Append a buffer to the given rule
+    buffer = HCubature.hcubature_buffer(f, _zeros(FP, 1), _ones(FP, 2))
+    rule = HAdaptiveCubature(rule.kwargs..., buffer = buffer)
+
+    # Convert the Rope into Segments, sum the integrals of those
+    _subintegral(seg) = _integral(f, seg, rule; FP = FP, rule.kwargs...)
+    return sum(_subintegral, Meshes.segments(rope))
+end


### PR DESCRIPTION
## Changes
- For geometries that must be decomposed into multiple pieces, use `HCubature.hcubature_buffer` to pre-allocate a buffer that can be re-used.

## Conclusion
Performance did not improve when using this for `Rope` or `CylinderSurface`.