### PR TITLE
Fix bug where integral fails when Enzyme ext not loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implemented a more efficient internal parametric transformation for `Meshes.Tetrahedron`, resulting in about an 80% integral performance improvement.
 
+### Fixed
+
+- Fixed a bug where `integral` would default to `diff_method=AutoEnzyme()` even when the Enzyme extension isn't loaded.
+
 
 ## [0.16.0] - 2024-12-14
 

--- a/ext/MeshIntegralsEnzymeExt.jl
+++ b/ext/MeshIntegralsEnzymeExt.jl
@@ -16,8 +16,8 @@ function MeshIntegrals.jacobian(
     return Meshes.to.(Enzyme.jacobian(Enzyme.Forward, geometry, ts...))
 end
 
-# Supports all geometries except for a few
-# See GitHub Issue #154 for more information.
+# Supports all geometries except for those that throw errors
+# See GitHub Issue #154 for more information
 MeshIntegrals.supports_autoenzyme(::Type{<:Meshes.Geometry}) = true
 MeshIntegrals.supports_autoenzyme(::Type{<:Meshes.BezierCurve}) = false
 MeshIntegrals.supports_autoenzyme(::Type{<:Meshes.CylinderSurface}) = false

--- a/ext/MeshIntegralsEnzymeExt.jl
+++ b/ext/MeshIntegralsEnzymeExt.jl
@@ -18,10 +18,10 @@ end
 
 # Supports all geometries except for a few
 # See GitHub Issue #154 for more information.
-supports_autoenzyme(::Type{<:Meshes.Geometry}) = true
-supports_autoenzyme(::Type{<:Meshes.BezierCurve}) = false
-supports_autoenzyme(::Type{<:Meshes.CylinderSurface}) = false
-supports_autoenzyme(::Type{<:Meshes.Cylinder}) = false
-supports_autoenzyme(::Type{<:Meshes.ParametrizedCurve}) = false
+MeshIntegrals.supports_autoenzyme(::Type{<:Meshes.Geometry}) = true
+MeshIntegrals.supports_autoenzyme(::Type{<:Meshes.BezierCurve}) = false
+MeshIntegrals.supports_autoenzyme(::Type{<:Meshes.CylinderSurface}) = false
+MeshIntegrals.supports_autoenzyme(::Type{<:Meshes.Cylinder}) = false
+MeshIntegrals.supports_autoenzyme(::Type{<:Meshes.ParametrizedCurve}) = false
 
 end

--- a/ext/MeshIntegralsEnzymeExt.jl
+++ b/ext/MeshIntegralsEnzymeExt.jl
@@ -16,4 +16,12 @@ function MeshIntegrals.jacobian(
     return Meshes.to.(Enzyme.jacobian(Enzyme.Forward, geometry, ts...))
 end
 
+# Supports all geometries except for a few
+# See GitHub Issue #154 for more information.
+supports_autoenzyme(::Type{<:Meshes.Geometry}) = true
+supports_autoenzyme(::Type{<:Meshes.BezierCurve}) = false
+supports_autoenzyme(::Type{<:Meshes.CylinderSurface}) = false
+supports_autoenzyme(::Type{<:Meshes.Cylinder}) = false
+supports_autoenzyme(::Type{<:Meshes.ParametrizedCurve}) = false
+
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,21 +13,24 @@ end
 ################################################################################
 
 """
-    supports_autoenzyme(geometry)
+    supports_autoenzyme(geometry::Geometry)
+    supports_autoenzyme(type::Type{<:Geometry})
 
 Return whether a geometry (or geometry type) has a parametric function that can be
 differentiated with Enzyme. See GitHub Issue #154 for more information.
 """
 function supports_autoenzyme end
 
-# Returns false on all geometries when Enzyme extension not loaded
-supports_autoenzyme(::Any) = false
+# Returns false for all geometries when Enzyme extension is not loaded
+supports_autoenzyme(::Type{<:Any}) = false
+
+# If provided a geometry instance, re-run with the type as argument
 supports_autoenzyme(::G) where {G <: Geometry} = supports_autoenzyme(G)
 
 """
     _check_diff_method_support(::Geometry, ::DifferentiationMethod) -> nothing
 
-Throw an error if incompatible geometry-diff_method combination detected.
+Throw an error if incompatible combination {geometry, diff_method} detected.
 """
 _check_diff_method_support(::Geometry, ::DifferentiationMethod) = nothing
 function _check_diff_method_support(geometry::Geometry, ::AutoEnzyme)
@@ -47,21 +50,21 @@ function _default_diff_method(
     FP::Type{T}
 ) where {G <: Geometry, T <: AbstractFloat}
     # Enzyme only works with these FP types
-    EnzymeSupportedFPs = Union{Float32, Float64}
+    uses_Enzyme_supported_FP_type = (FP <: Union{Float32, Float64})
 
-    if supports_autoenzyme(G) && (FP <: EnzymeSupportedFPs)
-        AutoEnzyme()
+    if supports_autoenzyme(G) && uses_Enzyme_supported_FP_type
+        return AutoEnzyme()
     else
-        FiniteDifference()
+        return FiniteDifference()
     end
 end
 
-# Re-run with the Geometry type as first argument
+# If provided a geometry instance, re-run with the type as argument
 function _default_diff_method(
     ::G,
     ::Type{T}
 ) where {G <: Geometry, T <: AbstractFloat}
-    _default_diff_method(G, T)
+    return _default_diff_method(G, T)
 end
 
 ################################################################################

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,12 +32,17 @@ supports_autoenzyme(::G) where {G <: Geometry} = supports_autoenzyme(G)
 
 Throw an error if incompatible combination {geometry, diff_method} detected.
 """
-_check_diff_method_support(::Geometry, ::DifferentiationMethod) = nothing
+function _check_diff_method_support end
+
+# If diff_method == Enzyme, then perform check
 function _check_diff_method_support(geometry::Geometry, ::AutoEnzyme)
     if !supports_autoenzyme(geometry)
         throw(ArgumentError("AutoEnzyme not supported for this geometry."))
     end
 end
+
+# If diff_method != AutoEnzyme, then do nothing
+_check_diff_method_support(::Geometry, ::DifferentiationMethod) = nothing
 
 """
     _default_diff_method(geometry, FP)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,11 +18,10 @@ end
 Return whether a geometry (or geometry type) has a parametric function that can be
 differentiated with Enzyme. See GitHub Issue #154 for more information.
 """
-supports_autoenzyme(::Type{<:Meshes.Geometry}) = true
-supports_autoenzyme(::Type{<:Meshes.BezierCurve}) = false
-supports_autoenzyme(::Type{<:Meshes.CylinderSurface}) = false
-supports_autoenzyme(::Type{<:Meshes.Cylinder}) = false
-supports_autoenzyme(::Type{<:Meshes.ParametrizedCurve}) = false
+function supports_autoenzyme end
+
+# Returns false on all geometries when Enzyme extension not loaded
+supports_autoenzyme(::Any) = false
 supports_autoenzyme(::G) where {G <: Geometry} = supports_autoenzyme(G)
 
 """
@@ -44,16 +43,24 @@ Return an instance of the default DifferentiationMethod for a particular geometr
 (or geometry type) and floating point type.
 """
 function _default_diff_method(
-        g::Type{G}, FP::Type{T}
+    ::Type{G},
+    FP::Type{T}
 ) where {G <: Geometry, T <: AbstractFloat}
-    if supports_autoenzyme(g) && FP <: Union{Float32, Float64}
+    # Enzyme only works with these FP types
+    EnzymeSupportedFPs = Union{Float32, Float64}
+
+    if supports_autoenzyme(G) && (FP <: EnzymeSupportedFPs)
         AutoEnzyme()
     else
         FiniteDifference()
     end
 end
 
-function _default_diff_method(::G, ::Type{T}) where {G <: Geometry, T <: AbstractFloat}
+# Re-run with the Geometry type as first argument
+function _default_diff_method(
+    ::G,
+    ::Type{T}
+) where {G <: Geometry, T <: AbstractFloat}
     _default_diff_method(G, T)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -16,7 +16,7 @@ end
     supports_autoenzyme(geometry::Geometry)
     supports_autoenzyme(type::Type{<:Geometry})
 
-Return whether a geometry (or geometry type) has a parametric function that can be
+Return whether a geometry or geometry type has a parametric function that can be
 differentiated with Enzyme. See GitHub Issue #154 for more information.
 """
 function supports_autoenzyme end
@@ -52,8 +52,8 @@ Return an instance of the default DifferentiationMethod for a particular geometr
 """
 function _default_diff_method(
         ::Type{G},
-        FP::Type{T}
-) where {G <: Geometry, T <: AbstractFloat}
+        ::Type{FP}
+) where {G <: Geometry, FP <: AbstractFloat}
     # Enzyme only works with these FP types
     uses_Enzyme_supported_FP_type = (FP <: Union{Float32, Float64})
 
@@ -67,9 +67,9 @@ end
 # If provided a geometry instance, re-run with the type as argument
 function _default_diff_method(
         ::G,
-        ::Type{T}
-) where {G <: Geometry, T <: AbstractFloat}
-    return _default_diff_method(G, T)
+        ::Type{FP}
+) where {G <: Geometry, FP <: AbstractFloat}
+    return _default_diff_method(G, FP)
 end
 
 ################################################################################

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -48,7 +48,10 @@ This file includes tests for:
     end
 
     # Shortcut constructor for geometries with typical support structure
-    function SupportStatus(g::Geometry, autoenzyme = MeshIntegrals.supports_autoenzyme(g))
+    function SupportStatus(
+            g::Geometry;
+            autoenzyme = true # Assume supported unless explicitly flagged
+    )
         N = Meshes.paramdim(g)
         if N == 1
             # line/curve
@@ -73,11 +76,15 @@ This file includes tests for:
         end
     end
 
+    # Generate applicable tests for this geometry
     function runtests(
-            testable::TestableGeometry,
-            supports::SupportStatus = SupportStatus(testable.geometry);
+            testable::TestableGeometry;
+            autoenzyme = true, # Assume supported unless explicitly flagged
             rtol = sqrt(eps())
     )
+        # Determine support matrix for this geometry
+        supports = SupportStatus(testable.geometry; autoenzyme = autoenzyme)
+
         # Test alias functions
         for alias in (lineintegral, surfaceintegral, volumeintegral)
             # if supports.alias
@@ -195,7 +202,7 @@ end
 
     # Package and run tests
     testable = TestableGeometry(integrand, curve, solution)
-    runtests(testable; rtol = 0.5e-2)
+    runtests(testable; autoenzyme = false, rtol = 0.5e-2)
 end
 
 @testitem "Meshes.Box 1D" setup=[Combinations] begin
@@ -336,7 +343,7 @@ end
 
     # Package and run tests
     testable = TestableGeometry(integrand, cyl, solution)
-    runtests(testable)
+    runtests(testable; autoenzyme = false)
 end
 
 @testitem "Meshes.CylinderSurface" setup=[Combinations] begin
@@ -351,7 +358,7 @@ end
 
     # Package and run tests
     testable = TestableGeometry(integrand, cyl, solution)
-    runtests(testable)
+    runtests(testable; autoenzyme = false)
 end
 
 @testitem "Meshes.Disk" setup=[Combinations] begin
@@ -488,9 +495,9 @@ end
 
     # Package and run tests
     testable_cart = TestableGeometry(integrand, curve_cart, solution)
-    runtests(testable_cart)
+    runtests(testable_cart; autoenzyme = false)
     testable_polar = TestableGeometry(integrand, curve_polar, solution)
-    runtests(testable_polar)
+    runtests(testable_polar; autoenzyme = false)
 end
 
 @testitem "Meshes.Plane" setup=[Combinations] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -129,16 +129,15 @@ This file includes tests for:
         )
 
         for (supported, method) in iter_diff_methods
+            # Aliases for improved code readability
             f = testable.integrand
             geometry = testable.geometry
             sol = testable.solution
 
             if supported
                 @test integral(f, geometry; diff_method = method)≈sol rtol=rtol
-                @test MeshIntegrals.supports_autoenzyme(testable.geometry) == true
             else
                 @test_throws "not supported" integral(f, geometry; diff_method = method)
-                @test MeshIntegrals.supports_autoenzyme(testable.geometry) == false
             end
         end # for
     end # function

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -117,17 +117,20 @@ This file includes tests for:
         end # for
 
         iter_diff_methods = (
+            (true, FiniteDifference()),
             (supports.autoenzyme, AutoEnzyme()),
         )
 
-        for (supported, diff_method) in iter_diff_methods
+        for (supported, method) in iter_diff_methods
+            f = testable.integrand
+            geometry = testable.geometry
+            sol = testable.solution
+
             if supported
-                @test integral(
-                    testable.integrand, testable.geometry; diff_method = diff_method)≈testable.solution rtol=rtol
+                @test integral(f, geometry; diff_method = method)≈sol rtol=rtol
                 @test MeshIntegrals.supports_autoenzyme(testable.geometry) == true
             else
-                @test_throws "not supported" integral(
-                    testable.integrand, testable.geometry; diff_method = diff_method)
+                @test_throws "not supported" integral(f, geometry; diff_method = method)
                 @test MeshIntegrals.supports_autoenzyme(testable.geometry) == false
             end
         end # for

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -200,7 +200,7 @@ end
 
     # Package and run tests
     testable = TestableGeometry(integrand, curve, solution)
-    runtests(testable; autoenzyme = false, rtol = 0.5e-2)
+    runtests(testable; rtol = 0.5e-2)
 end
 
 @testitem "Meshes.Box 1D" setup=[Combinations] begin

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -85,6 +85,9 @@ This file includes tests for:
         # Determine support matrix for this geometry
         supports = SupportStatus(testable.geometry; autoenzyme = autoenzyme)
 
+        # Ensure consistency of SupportStatus with supports_autoenzyme
+        @test MeshIntegrals.supports_autoenzyme(testable.geometry) == supports.autoenzyme
+
         # Test alias functions
         for alias in (lineintegral, surfaceintegral, volumeintegral)
             # if supports.alias
@@ -93,15 +96,14 @@ This file includes tests for:
             else
                 @test_throws "not supported" alias(testable.integrand, testable.geometry)
             end
-        end
+        end # for
 
+        # Iteratively test all IntegrationRules
         iter_rules = (
             (supports.gausskronrod, GaussKronrod()),
             (supports.gausslegendre, GaussLegendre(100)),
             (supports.hadaptivecubature, HAdaptiveCubature())
         )
-
-        # Test rules
         for (supported, rule) in iter_rules
             if supported
                 # Scalar integrand
@@ -123,11 +125,11 @@ This file includes tests for:
             end
         end # for
 
+        # Iteratively test all DifferentiationMethods
         iter_diff_methods = (
             (true, FiniteDifference()),
             (supports.autoenzyme, AutoEnzyme())
         )
-
         for (supported, method) in iter_diff_methods
             # Aliases for improved code readability
             f = testable.integrand

--- a/test/combinations.jl
+++ b/test/combinations.jl
@@ -468,7 +468,7 @@ end
     runtests(testable)
 end
 
-@testitem "ParametrizedCurve" setup=[Combinations] begin
+@testitem "Meshes.ParametrizedCurve" setup=[Combinations] begin
     using CoordRefSystems: Polar
 
     # Geometries

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -25,12 +25,22 @@ end
     @test _ones(Float32, 2) == (1.0f0, 1.0f0)
 end
 
-@testitem "Differentiation" setup=[Utils] begin
-    # _default_diff_method
-    sphere = Sphere(Point(0, 0, 0), 1.0)
-    @test _default_diff_method(Meshes.Sphere, Float64) isa AutoEnzyme
-    @test _default_diff_method(sphere, Float64) isa AutoEnzyme
-    @test _default_diff_method(sphere, BigFloat) isa FiniteDifference
+@testitem "Differentiation (Enzyme extension loaded)" setup=[Utils] begin
+    # _default_diff_method -- using type or instance, Enzyme-supported combination
+    let sphere = Sphere(Point(0, 0, 0), 1.0)
+        @test _default_diff_method(Meshes.Sphere, Float64) isa AutoEnzyme
+        @test _default_diff_method(sphere, Float64) isa AutoEnzyme
+    end
+
+    # _default_diff_method -- Enzyme-unsupported FP types
+    @test _default_diff_method(Meshes.Sphere, Float32) isa FiniteDifference
+    @test _default_diff_method(Meshes.Sphere, BigFloat) isa FiniteDifference
+
+    # _default_diff_method -- geometries that currently error with AutoEnzyme
+    @test _default_diff_method(Meshes.BezierCurve, Float64) isa FiniteDifference
+    @test _default_diff_method(Meshes.CylinderSurface, Float64) isa FiniteDifference
+    @test _default_diff_method(Meshes.Cylinder, Float64) isa FiniteDifference
+    @test _default_diff_method(Meshes.ParametrizedCurve, Float64) isa FiniteDifference
 
     # FiniteDifference
     @test FiniteDifference().ε ≈ 1e-6
@@ -43,6 +53,18 @@ end
     box = Box(Point(0, 0), Point(1, 1))
     @test_throws ArgumentError jacobian(box, zeros(3), FiniteDifference())
     @test_throws ArgumentError jacobian(box, zeros(3), AutoEnzyme())
+end
+
+@testitem "Differentiation (Enzyme extension not loaded)" setup=[Utils] begin
+    using Meshes
+    using MeshIntegrals
+    using MeshIntegrals: _default_diff_method
+
+    # _default_diff_method -- using type or instance, Enzyme-supported combination
+    let sphere = Sphere(Point(0, 0, 0), 1.0)
+        @test _default_diff_method(Meshes.Sphere, Float64) isa FiniteDifference
+        @test _default_diff_method(sphere, Float64) isa FiniteDifference
+    end
 end
 
 @testitem "_ParametricGeometry" setup=[Utils] begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -25,7 +25,7 @@ end
     @test _ones(Float32, 2) == (1.0f0, 1.0f0)
 end
 
-@testitem "Differentiation (Enzyme extension loaded)" setup=[Utils] begin
+@testitem "Differentiation (EnzymeExt loaded)" setup=[Utils] begin
     # _default_diff_method -- using type or instance, Enzyme-supported combination
     let sphere = Sphere(Point(0, 0, 0), 1.0)
         @test _default_diff_method(Meshes.Sphere, Float64) isa AutoEnzyme
@@ -53,18 +53,6 @@ end
     box = Box(Point(0, 0), Point(1, 1))
     @test_throws ArgumentError jacobian(box, zeros(3), FiniteDifference())
     @test_throws ArgumentError jacobian(box, zeros(3), AutoEnzyme())
-end
-
-@testitem "Differentiation (Enzyme extension not loaded)" begin
-    using Meshes
-    using MeshIntegrals
-    using MeshIntegrals: _default_diff_method
-
-    # _default_diff_method -- using type or instance, Enzyme-supported combination
-    let sphere = Sphere(Point(0, 0, 0), 1.0)
-        @test _default_diff_method(Meshes.Sphere, Float64) isa FiniteDifference
-        @test _default_diff_method(sphere, Float64) isa FiniteDifference
-    end
 end
 
 @testitem "_ParametricGeometry" setup=[Utils] begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -33,7 +33,7 @@ end
     end
 
     # _default_diff_method -- Enzyme-unsupported FP types
-    @test _default_diff_method(Meshes.Sphere, Float32) isa FiniteDifference
+    @test _default_diff_method(Meshes.Sphere, Float16) isa FiniteDifference
     @test _default_diff_method(Meshes.Sphere, BigFloat) isa FiniteDifference
 
     # _default_diff_method -- geometries that currently error with AutoEnzyme

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -26,6 +26,9 @@ end
 end
 
 @testitem "Differentiation (EnzymeExt loaded)" setup=[Utils] begin
+    # supports_autoenzyme(::Type{<:Any})
+    @test MeshIntegrals.supports_autoenzyme(Nothing) == false
+
     # _default_diff_method -- using type or instance, Enzyme-supported combination
     let sphere = Sphere(Point(0, 0, 0), 1.0)
         @test _default_diff_method(Meshes.Sphere, Float64) isa AutoEnzyme

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -55,7 +55,7 @@ end
     @test_throws ArgumentError jacobian(box, zeros(3), AutoEnzyme())
 end
 
-@testitem "Differentiation (Enzyme extension not loaded)" setup=[Utils] begin
+@testitem "Differentiation (Enzyme extension not loaded)" begin
     using Meshes
     using MeshIntegrals
     using MeshIntegrals: _default_diff_method


### PR DESCRIPTION
I discovered a bug where a clean install of Meshes without Enzyme will still default to using `AutoEnzyme` but won’t have the appropriate method defined.

I’m currently trying to fix this by signaling whether the extension is loaded via multiple dispatch. I created a `supports_autoenzyme(::Any) = false` method and moved the rest into the extension itself. That way, without the extension loaded, all calls will return false. When the extension is loaded, the methods with more specific argument types will take over.