### PR TITLE
Add `Base.show` for integration rules

### DIFF
--- a/src/integration_rules.jl
+++ b/src/integration_rules.jl
@@ -18,6 +18,11 @@ struct GaussKronrod <: IntegrationRule
     GaussKronrod(; kwargs...) = new(kwargs)
 end
 
+function Base.show(io::IO, rule::GaussKronrod)
+    print(io, "GaussKronrod(; ",
+        join([string(k) * " = " * string(v) for (k, v) in pairs(rule.kwargs)], ", "), ")")
+end
+
 """
     GaussLegendre(n)
 
@@ -39,6 +44,10 @@ struct GaussLegendre <: IntegrationRule
     GaussLegendre(n::Int64) = new(n, FastGaussQuadrature.gausslegendre(n)...)
 end
 
+function Base.show(io::IO, rule::GaussLegendre)
+    print(io, "GaussLegendre(", rule.n, ")")
+end
+
 """
     HAdaptiveCubature(kwargs...)
 
@@ -49,4 +58,9 @@ The h-adaptive cubature rule implemented by
 struct HAdaptiveCubature <: IntegrationRule
     kwargs::Base.Pairs
     HAdaptiveCubature(; kwargs...) = new(kwargs)
+end
+
+function Base.show(io::IO, rule::HAdaptiveCubature)
+    print(io, "HAdaptiveCubature(; ",
+        join([string(k) * " = " * string(v) for (k, v) in pairs(rule.kwargs)], ", "), ")")
 end

--- a/src/integration_rules.jl
+++ b/src/integration_rules.jl
@@ -2,6 +2,10 @@
 #                           Integration Rules
 ################################################################################
 
+function _kwargs_to_string(kwargs)
+    return join([string(k) * " = " * string(v) for (k, v) in pairs(kwargs)], ", ")
+end
+
 abstract type IntegrationRule end
 
 """
@@ -19,8 +23,7 @@ struct GaussKronrod <: IntegrationRule
 end
 
 function Base.show(io::IO, rule::GaussKronrod)
-    print(io, "GaussKronrod(; ",
-        join([string(k) * " = " * string(v) for (k, v) in pairs(rule.kwargs)], ", "), ")")
+    print(io, "GaussKronrod(; ", _kwargs_to_string(rule.kwargs), ")")
 end
 
 """
@@ -61,6 +64,5 @@ struct HAdaptiveCubature <: IntegrationRule
 end
 
 function Base.show(io::IO, rule::HAdaptiveCubature)
-    print(io, "HAdaptiveCubature(; ",
-        join([string(k) * " = " * string(v) for (k, v) in pairs(rule.kwargs)], ", "), ")")
+    print(io, "HAdaptiveCubature(; ", _kwargs_to_string(rule.kwargs), ")")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,6 +7,14 @@
     import Enzyme
 end
 
+@testitem "Integration Rules" begin
+    @test sprint(show, GaussKronrod(; atol = 1e-12, rtol = 1e-10)) ==
+          "GaussKronrod(; atol = 1.0e-12, rtol = 1.0e-10)"
+
+    @test sprint(show, GaussLegendre(5)) == "GaussLegendre(5)"
+    @test sprint(show, HAdaptiveCubature()) == "HAdaptiveCubature(; )"
+end
+
 @testitem "Utilities" setup=[Utils] begin
     # _KVector
     v = Meshes.Vec(3, 4)


### PR DESCRIPTION
This way of showing the integration rules ensures that you can still copy-paste the result in the REPL and obtain the same object.
Closes #185.